### PR TITLE
feat(orion): SAO-issued entity bundles + 5-provider LLM proxy

### DIFF
--- a/COORDINATION.md
+++ b/COORDINATION.md
@@ -1,0 +1,17 @@
+# SAO Coordination
+
+The local OrionII integration MVP is coordinated by these docs:
+
+- `docs/orion-sao-mvp.md` for the shared API contract.
+- `docs/runbooks/local-orion-sao-mvp.md` for the local end-to-end runbook.
+- `C:\Repo\OrionII\docs\sao-mvp-client.md` for OrionII client behavior.
+
+Keep browser auth cookie-based and CSRF-protected. The Orion MVP uses a separate Bearer-authenticated
+machine route group under `/api/orion`.
+
+Bootstrap boundaries:
+
+- Production and cloud environments use the Azure conversational installer.
+- Local Docker MVP work uses `sao-server bootstrap-local` from the Compose service with
+  `SAO_LOCAL_BOOTSTRAP=true`.
+- Local OrionII tokens come from `sao-server mint-dev-token` and are only for MVP/dev testing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +85,15 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "argon2"
@@ -393,6 +408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +570,17 @@ checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -744,6 +779,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1504,6 +1549,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2323,6 +2378,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
  "tower-http 0.5.2",
@@ -2332,6 +2388,7 @@ dependencies = [
  "uuid",
  "webauthn-rs",
  "webauthn-rs-proto",
+ "zip",
 ]
 
 [[package]]
@@ -2566,6 +2623,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -4102,7 +4165,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ webauthn-rs = "0.5"
 webauthn-rs-proto = "0.5"
 openidconnect = { version = "4", default-features = false, features = ["reqwest", "rustls-tls"] }
 url = "2"
+zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ docker run --rm -it \
   ghcr.io/jbcupps/sao-installer:latest
 ```
 
+Windows PowerShell:
+
+```powershell
+docker run --rm -it -e ANTHROPIC_API_KEY="sk-ant-your-key-here" ghcr.io/jbcupps/sao-installer:latest
+```
+
 In one guided session the installer signs you into Azure, validates permissions, provisions the SAO control plane, and prints the live URL when the platform is ready.
 
 The default Azure deployment now hardens the runtime by:
@@ -153,15 +159,76 @@ Write-Host "SAO baseline Entra ID security groups are ready."
 - Deployment contract and operator workflow: [docs/SAO_INSTALLER_SPEC.md](docs/SAO_INSTALLER_SPEC.md)
 - Vault, registry, and governed skill surfaces: [docs/VAULT_AND_REGISTRY.md](docs/VAULT_AND_REGISTRY.md)
 - Skills as governed artifacts: [docs/agent_archetype.md](docs/agent_archetype.md)
+- OrionII entity contract (LLM proxy, entity JWT, bundle download): [docs/orion-sao-mvp.md](docs/orion-sao-mvp.md)
 - Detailed architecture source: [documents/SAO_Orion_Architecture_Analysis_v2.docx](documents/SAO_Orion_Architecture_Analysis_v2.docx)
+
+## Entity Lifecycle (OrionII)
+
+SAO is the issuer of OrionII entities. The full flow is in
+[docs/runbooks/local-orion-sao-mvp.md](docs/runbooks/local-orion-sao-mvp.md). At a glance:
+
+1. Admin signs in, opens **/admin/llm-providers**, and per-provider:
+   - OpenAI / Anthropic / xAI Grok / Google Gemini — paste the API key, tick approved models,
+     set a default, click **Test connection** to confirm with a real ping.
+   - Ollama — set the base URL, click **Refresh models** to pull the live list, tick allowed
+     ones.
+
+   Keys are stored encrypted in the vault; admins never see the key after save. **Every entity
+   call goes through `POST /api/llm/generate` on SAO**, so keys never leave the server, every
+   prompt is auditable, and key rotation/revocation is instant.
+2. User signs in, opens **/agents**, registers a new entity (name + provider + Id/Ego model).
+3. User clicks **Download bundle**. SAO mints a fresh OIDC-shaped entity JWT (revoking any
+   prior tokens for that agent), packages a ZIP with `config.json` + `OrionII-Setup.msi`.
+4. User installs OrionII, drops `config.json` into `%APPDATA%\OrionII\`, launches the app.
+5. OrionII adopts the SAO-assigned identity, calls `POST /api/llm/generate` for every Id/Ego
+   prompt — keys never leave SAO. Per-agent egress events stream into **/agents/:id/events**.
+
+Deleting an agent in SAO bulk-revokes its tokens.
 
 ## Development & Contributing
 
-For local development, the Azure installer is still the primary story, but the repo includes a local Compose workflow for integration work:
+For local development, the Azure installer is still the production story, but the repo includes a local Compose workflow for integration work:
 
 ```bash
 POSTGRES_PASSWORD=local-dev-only-change-me docker compose -f docker/docker-compose.yml up --build
 ```
+
+Windows PowerShell:
+
+```powershell
+$env:POSTGRES_PASSWORD = "local-dev-only-change-me"
+$env:SAO_JWT_SECRET = "local-dev-only-change-me"
+docker compose -f docker\docker-compose.yml up --build
+```
+
+After Compose starts, use the local development bootstrap command from `docs/runbooks/local-orion-sao-mvp.md` to initialize the local vault and admin user without enabling a browser setup wizard.
+
+To validate the local SAO side of the OrionII integration:
+
+```powershell
+# Minimum: health, bootstrap, dev token, policy pull, egress ack.
+.\scripts\local-mvp-smoke.ps1 -StartCompose
+
+# Full bundle round-trip: also configures Ollama, creates an agent, downloads the bundle.
+.\scripts\local-mvp-smoke.ps1 -StartCompose -OllamaBaseUrl "http://host.docker.internal:11434" -OllamaModel "llama3.2"
+```
+
+To serve real OrionII installers from `/api/agents/:id/bundle`, build the MSI in OrionII first and
+point Compose at it via two host env vars before running `up`:
+
+```powershell
+# In OrionII:
+npm run tauri build -- --bundles msi
+
+# In SAO (host shell):
+$env:SAO_ORION_INSTALLER_DIR      = "C:\Repo\OrionII\src-tauri\target\release\bundle\msi"
+$env:SAO_ORION_INSTALLER_FILENAME = "OrionII_0.1.0_x64_en-US.msi"
+$env:SAO_PUBLIC_BASE_URL          = "http://localhost:3100"
+docker compose -f docker\docker-compose.yml up --build
+```
+
+The Compose file mounts `SAO_ORION_INSTALLER_DIR` read-only at `/installer` inside the container
+and exposes the file via `SAO_ORION_INSTALLER_PATH=/installer/<filename>`.
 
 Useful validation commands:
 

--- a/crates/sao-server/Cargo.toml
+++ b/crates/sao-server/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
@@ -29,3 +30,4 @@ url = { workspace = true }
 openidconnect = { workspace = true }
 reqwest = { workspace = true }
 rusqlite = { workspace = true }
+zip = { workspace = true }

--- a/crates/sao-server/src/auth/agent_tokens.rs
+++ b/crates/sao-server/src/auth/agent_tokens.rs
@@ -1,0 +1,232 @@
+//! Entity identity tokens (OIDC-shaped JWTs for non-human principals).
+//!
+//! Each Orion entity is an identity in its own right. When a user downloads a bundle, SAO mints
+//! a long-lived JWT that the entity carries as its identity proof on every API call. The token
+//! shape is intentionally OIDC-compatible so a future Entra/external-IdP migration is just a
+//! swap of the issuance + verification path; the bundle/runtime contract stays the same.
+//!
+//! Claims:
+//!   sub             entity's agent_id
+//!   jti             agent_tokens row id (revocation key)
+//!   iss/aud         "sao" / "sao-api"
+//!   principal_type  "non_human"   (distinguishes from user JWTs)
+//!   entity_kind     "orion"
+//!   entity_name     friendly name
+//!   human_owner     creating user_id
+//!   scope           space-separated scopes ("orion:policy orion:egress llm:generate")
+
+use chrono::{Duration, Utc};
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::db::agent_tokens as db;
+
+pub const DEFAULT_SCOPE: &str = "orion:policy orion:egress llm:generate";
+pub const ENTITY_KIND_ORION: &str = "orion";
+pub const PRINCIPAL_TYPE_NON_HUMAN: &str = "non_human";
+const ISSUER: &str = "sao";
+const AUDIENCE: &str = "sao-api";
+const DEFAULT_TTL_DAYS: i64 = 365;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentClaims {
+    pub iss: String,
+    pub aud: String,
+    pub sub: String,
+    pub jti: String,
+    pub iat: i64,
+    pub nbf: i64,
+    pub exp: i64,
+    pub principal_type: String,
+    pub entity_kind: String,
+    pub entity_name: String,
+    pub human_owner: String,
+    pub scope: String,
+}
+
+impl AgentClaims {
+    pub fn agent_id(&self) -> Result<Uuid, AgentTokenError> {
+        Uuid::parse_str(&self.sub).map_err(|_| AgentTokenError::Invalid("sub is not a UUID"))
+    }
+
+    pub fn jti_uuid(&self) -> Result<Uuid, AgentTokenError> {
+        Uuid::parse_str(&self.jti).map_err(|_| AgentTokenError::Invalid("jti is not a UUID"))
+    }
+
+    pub fn human_owner_id(&self) -> Result<Uuid, AgentTokenError> {
+        Uuid::parse_str(&self.human_owner)
+            .map_err(|_| AgentTokenError::Invalid("human_owner is not a UUID"))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AgentTokenError {
+    #[error("agent token database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("agent token jwt error: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("agent token rejected: {0}")]
+    Invalid(&'static str),
+}
+
+pub struct MintedAgentToken {
+    pub jwt: String,
+    pub jti: Uuid,
+    pub expires_at: chrono::DateTime<Utc>,
+}
+
+pub async fn mint_entity_token(
+    pool: &PgPool,
+    jwt_secret: &[u8; 32],
+    agent_id: Uuid,
+    agent_name: &str,
+    issuer_user: Uuid,
+) -> Result<MintedAgentToken, AgentTokenError> {
+    let now = Utc::now();
+    let expires_at = now + Duration::days(DEFAULT_TTL_DAYS);
+
+    let row = db::insert_token(pool, agent_id, issuer_user, Some(expires_at), DEFAULT_SCOPE).await?;
+
+    let claims = AgentClaims {
+        iss: ISSUER.to_string(),
+        aud: AUDIENCE.to_string(),
+        sub: agent_id.to_string(),
+        jti: row.id.to_string(),
+        iat: now.timestamp(),
+        nbf: now.timestamp(),
+        exp: expires_at.timestamp(),
+        principal_type: PRINCIPAL_TYPE_NON_HUMAN.to_string(),
+        entity_kind: ENTITY_KIND_ORION.to_string(),
+        entity_name: agent_name.to_string(),
+        human_owner: issuer_user.to_string(),
+        scope: DEFAULT_SCOPE.to_string(),
+    };
+
+    let jwt = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(jwt_secret),
+    )?;
+
+    Ok(MintedAgentToken {
+        jwt,
+        jti: row.id,
+        expires_at,
+    })
+}
+
+pub async fn validate_entity_token(
+    pool: &PgPool,
+    jwt_secret: &[u8; 32],
+    token: &str,
+) -> Result<AgentClaims, AgentTokenError> {
+    let mut validation = Validation::default();
+    validation.set_audience(&[AUDIENCE]);
+    validation.set_issuer(&[ISSUER]);
+
+    let data = decode::<AgentClaims>(token, &DecodingKey::from_secret(jwt_secret), &validation)?;
+    let claims = data.claims;
+
+    if claims.principal_type != PRINCIPAL_TYPE_NON_HUMAN {
+        return Err(AgentTokenError::Invalid("principal_type must be non_human"));
+    }
+
+    let jti = claims.jti_uuid()?;
+    let row = db::get_active(pool, jti)
+        .await?
+        .ok_or(AgentTokenError::Invalid("token revoked or unknown"))?;
+
+    if row.agent_id.to_string() != claims.sub {
+        return Err(AgentTokenError::Invalid("sub does not match revocation row"));
+    }
+
+    let _ = db::touch_last_used(pool, jti).await;
+
+    Ok(claims)
+}
+
+pub async fn revoke_for_agent(pool: &PgPool, agent_id: Uuid) -> Result<u64, AgentTokenError> {
+    Ok(db::revoke_for_agent(pool, agent_id).await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claims_round_trip_through_jwt() {
+        let secret = [9u8; 32];
+        let now = Utc::now();
+        let claims = AgentClaims {
+            iss: ISSUER.into(),
+            aud: AUDIENCE.into(),
+            sub: Uuid::nil().to_string(),
+            jti: Uuid::nil().to_string(),
+            iat: now.timestamp(),
+            nbf: now.timestamp(),
+            exp: (now + Duration::minutes(5)).timestamp(),
+            principal_type: PRINCIPAL_TYPE_NON_HUMAN.into(),
+            entity_kind: ENTITY_KIND_ORION.into(),
+            entity_name: "abigail".into(),
+            human_owner: Uuid::nil().to_string(),
+            scope: DEFAULT_SCOPE.into(),
+        };
+
+        let jwt = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(&secret),
+        )
+        .expect("encode");
+
+        let mut validation = Validation::default();
+        validation.set_audience(&[AUDIENCE]);
+        validation.set_issuer(&[ISSUER]);
+        let decoded =
+            decode::<AgentClaims>(&jwt, &DecodingKey::from_secret(&secret), &validation)
+                .expect("decode");
+
+        assert_eq!(decoded.claims.entity_name, "abigail");
+        assert_eq!(decoded.claims.principal_type, PRINCIPAL_TYPE_NON_HUMAN);
+        assert_eq!(decoded.claims.scope, DEFAULT_SCOPE);
+    }
+
+    #[test]
+    fn human_principal_token_rejected_by_validate_signature_only() {
+        // Validate that a JWT lacking principal_type=non_human (e.g., a user session) fails our
+        // entity validation before the DB lookup, so an attacker can't substitute a user JWT.
+        let secret = [9u8; 32];
+        let now = Utc::now();
+        let claims = AgentClaims {
+            iss: ISSUER.into(),
+            aud: AUDIENCE.into(),
+            sub: Uuid::nil().to_string(),
+            jti: Uuid::nil().to_string(),
+            iat: now.timestamp(),
+            nbf: now.timestamp(),
+            exp: (now + Duration::minutes(5)).timestamp(),
+            principal_type: "human".into(),
+            entity_kind: ENTITY_KIND_ORION.into(),
+            entity_name: "x".into(),
+            human_owner: Uuid::nil().to_string(),
+            scope: DEFAULT_SCOPE.into(),
+        };
+        let jwt = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(&secret),
+        )
+        .expect("encode");
+
+        let mut validation = Validation::default();
+        validation.set_audience(&[AUDIENCE]);
+        validation.set_issuer(&[ISSUER]);
+        let decoded =
+            decode::<AgentClaims>(&jwt, &DecodingKey::from_secret(&secret), &validation)
+                .expect("decode");
+        assert_ne!(decoded.claims.principal_type, PRINCIPAL_TYPE_NON_HUMAN);
+    }
+}

--- a/crates/sao-server/src/auth/mod.rs
+++ b/crates/sao-server/src/auth/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_tokens;
 pub mod middleware;
 pub mod oidc;
 pub mod session;

--- a/crates/sao-server/src/auth/session.rs
+++ b/crates/sao-server/src/auth/session.rs
@@ -1,5 +1,5 @@
-use chrono::{Duration, Utc};
 use axum::http::HeaderMap;
+use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -7,9 +7,7 @@ use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use uuid::Uuid;
 
-use crate::security::{
-    append_set_cookie, build_cookie, build_expired_cookie, CookieConfig,
-};
+use crate::security::{append_set_cookie, build_cookie, build_expired_cookie, CookieConfig};
 
 pub const ACCESS_COOKIE_NAME: &str = "sao_access_token";
 pub const REFRESH_COOKIE_NAME: &str = "sao_refresh_token";
@@ -28,12 +26,7 @@ pub struct Claims {
 
 /// Generate a random JWT secret if not provided via env.
 pub fn jwt_secret() -> [u8; 32] {
-    if let Ok(secret) = std::env::var("SAO_JWT_SECRET") {
-        let mut hasher = Sha256::new();
-        hasher.update(secret.as_bytes());
-        let result = hasher.finalize();
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&result);
+    if let Some(key) = jwt_secret_from_env() {
         return key;
     }
 
@@ -47,6 +40,22 @@ pub fn jwt_secret() -> [u8; 32] {
         "No SAO_JWT_SECRET set and no local secret could be persisted, using random key (sessions won't survive restarts)"
     );
     key
+}
+
+fn jwt_secret_from_env() -> Option<[u8; 32]> {
+    let secret = std::env::var("SAO_JWT_SECRET").ok()?;
+    let secret = secret.trim();
+    if secret.is_empty() {
+        tracing::warn!("Ignoring empty SAO_JWT_SECRET");
+        return None;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(secret.as_bytes());
+    let result = hasher.finalize();
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&result);
+    Some(key)
 }
 
 fn load_or_create_local_jwt_secret() -> Option<[u8; 32]> {
@@ -197,6 +206,26 @@ pub fn append_session_cookies(
 }
 
 pub fn append_cleared_session_cookies(headers: &mut HeaderMap, cookie_config: &CookieConfig) {
-    append_set_cookie(headers, &build_expired_cookie(ACCESS_COOKIE_NAME, cookie_config));
-    append_set_cookie(headers, &build_expired_cookie(REFRESH_COOKIE_NAME, cookie_config));
+    append_set_cookie(
+        headers,
+        &build_expired_cookie(ACCESS_COOKIE_NAME, cookie_config),
+    );
+    append_set_cookie(
+        headers,
+        &build_expired_cookie(REFRESH_COOKIE_NAME, cookie_config),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jwt_secret_ignores_empty_env_value() {
+        std::env::set_var("SAO_JWT_SECRET", "");
+        let key = jwt_secret_from_env();
+        std::env::remove_var("SAO_JWT_SECRET");
+
+        assert!(key.is_none());
+    }
 }

--- a/crates/sao-server/src/db/agent_tokens.rs
+++ b/crates/sao-server/src/db/agent_tokens.rs
@@ -1,0 +1,69 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// Several fields aren't read today — they're surfaced through the audit-log JSON when relevant
+// rather than every callsite reading them off the row.
+#[allow(dead_code)]
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AgentTokenRow {
+    pub id: Uuid,
+    pub agent_id: Uuid,
+    pub issued_by: Uuid,
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub scope: String,
+}
+
+pub async fn insert_token(
+    pool: &PgPool,
+    agent_id: Uuid,
+    issued_by: Uuid,
+    expires_at: Option<DateTime<Utc>>,
+    scope: &str,
+) -> Result<AgentTokenRow, sqlx::Error> {
+    sqlx::query_as::<_, AgentTokenRow>(
+        "INSERT INTO agent_tokens (agent_id, issued_by, expires_at, scope) \
+         VALUES ($1, $2, $3, $4) \
+         RETURNING id, agent_id, issued_by, issued_at, expires_at, revoked_at, last_used_at, scope",
+    )
+    .bind(agent_id)
+    .bind(issued_by)
+    .bind(expires_at)
+    .bind(scope)
+    .fetch_one(pool)
+    .await
+}
+
+pub async fn get_active(pool: &PgPool, jti: Uuid) -> Result<Option<AgentTokenRow>, sqlx::Error> {
+    sqlx::query_as::<_, AgentTokenRow>(
+        "SELECT id, agent_id, issued_by, issued_at, expires_at, revoked_at, last_used_at, scope \
+         FROM agent_tokens \
+         WHERE id = $1 AND revoked_at IS NULL \
+           AND (expires_at IS NULL OR expires_at > now())",
+    )
+    .bind(jti)
+    .fetch_optional(pool)
+    .await
+}
+
+pub async fn touch_last_used(pool: &PgPool, jti: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE agent_tokens SET last_used_at = now() WHERE id = $1")
+        .bind(jti)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn revoke_for_agent(pool: &PgPool, agent_id: Uuid) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE agent_tokens SET revoked_at = now() \
+         WHERE agent_id = $1 AND revoked_at IS NULL",
+    )
+    .bind(agent_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}

--- a/crates/sao-server/src/db/agents.rs
+++ b/crates/sao-server/src/db/agents.rs
@@ -12,25 +12,28 @@ pub struct AgentRow {
     pub capabilities: serde_json::Value,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub default_provider: Option<String>,
+    pub default_id_model: Option<String>,
+    pub default_ego_model: Option<String>,
 }
+
+const SELECT_COLS: &str = "owner_user_id, id, name, public_key, state, capabilities, created_at, updated_at, default_provider, default_id_model, default_ego_model";
 
 pub async fn list_agents(
     pool: &PgPool,
     owner_filter: Option<Uuid>,
 ) -> Result<Vec<AgentRow>, sqlx::Error> {
     if let Some(owner_user_id) = owner_filter {
-        sqlx::query_as::<_, AgentRow>(
-            "SELECT owner_user_id, id, name, public_key, state, capabilities, created_at, updated_at \
-             FROM agents WHERE owner_user_id = $1 ORDER BY created_at",
-        )
+        sqlx::query_as::<_, AgentRow>(&format!(
+            "SELECT {SELECT_COLS} FROM agents WHERE owner_user_id = $1 ORDER BY created_at"
+        ))
         .bind(owner_user_id)
         .fetch_all(pool)
         .await
     } else {
-        sqlx::query_as::<_, AgentRow>(
-            "SELECT owner_user_id, id, name, public_key, state, capabilities, created_at, updated_at \
-             FROM agents ORDER BY created_at",
-        )
+        sqlx::query_as::<_, AgentRow>(&format!(
+            "SELECT {SELECT_COLS} FROM agents ORDER BY created_at"
+        ))
         .fetch_all(pool)
         .await
     }
@@ -40,25 +43,43 @@ pub async fn create_agent(
     pool: &PgPool,
     owner_user_id: Uuid,
     name: &str,
+    default_provider: Option<&str>,
+    default_id_model: Option<&str>,
+    default_ego_model: Option<&str>,
 ) -> Result<AgentRow, sqlx::Error> {
-    sqlx::query_as::<_, AgentRow>(
-        "INSERT INTO agents (owner_user_id, name) VALUES ($1, $2) \
-         RETURNING owner_user_id, id, name, public_key, state, capabilities, created_at, updated_at",
-    )
+    sqlx::query_as::<_, AgentRow>(&format!(
+        "INSERT INTO agents (owner_user_id, name, default_provider, default_id_model, default_ego_model) \
+         VALUES ($1, $2, $3, $4, $5) RETURNING {SELECT_COLS}"
+    ))
     .bind(owner_user_id)
     .bind(name)
+    .bind(default_provider)
+    .bind(default_id_model)
+    .bind(default_ego_model)
     .fetch_one(pool)
     .await
 }
 
 pub async fn get_agent(pool: &PgPool, id: Uuid) -> Result<Option<AgentRow>, sqlx::Error> {
-    sqlx::query_as::<_, AgentRow>(
-        "SELECT owner_user_id, id, name, public_key, state, capabilities, created_at, updated_at \
-         FROM agents WHERE id = $1",
-    )
+    sqlx::query_as::<_, AgentRow>(&format!(
+        "SELECT {SELECT_COLS} FROM agents WHERE id = $1"
+    ))
     .bind(id)
     .fetch_optional(pool)
     .await
+}
+
+pub async fn last_egress_at(
+    pool: &PgPool,
+    agent_id: Uuid,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, sqlx::Error> {
+    let row: Option<(Option<chrono::DateTime<chrono::Utc>>,)> = sqlx::query_as(
+        "SELECT MAX(created_at) FROM orion_egress_events WHERE agent_id = $1",
+    )
+    .bind(agent_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.and_then(|r| r.0))
 }
 
 pub async fn delete_agent(pool: &PgPool, id: Uuid) -> Result<bool, sqlx::Error> {

--- a/crates/sao-server/src/db/llm_providers.rs
+++ b/crates/sao-server/src/db/llm_providers.rs
@@ -1,0 +1,69 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[allow(dead_code)] // updated_by is captured for audit rather than read directly
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct LlmProviderSettingsRow {
+    pub provider: String,
+    pub enabled: bool,
+    pub base_url: Option<String>,
+    pub approved_models: serde_json::Value,
+    pub default_model: Option<String>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(skip_serializing)]
+    pub updated_by: Option<Uuid>,
+}
+
+pub async fn list(pool: &PgPool) -> Result<Vec<LlmProviderSettingsRow>, sqlx::Error> {
+    sqlx::query_as::<_, LlmProviderSettingsRow>(
+        "SELECT provider, enabled, base_url, approved_models, default_model, updated_at, updated_by \
+         FROM llm_provider_settings ORDER BY provider",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+pub async fn get(
+    pool: &PgPool,
+    provider: &str,
+) -> Result<Option<LlmProviderSettingsRow>, sqlx::Error> {
+    sqlx::query_as::<_, LlmProviderSettingsRow>(
+        "SELECT provider, enabled, base_url, approved_models, default_model, updated_at, updated_by \
+         FROM llm_provider_settings WHERE provider = $1",
+    )
+    .bind(provider)
+    .fetch_optional(pool)
+    .await
+}
+
+pub async fn upsert(
+    pool: &PgPool,
+    provider: &str,
+    enabled: bool,
+    base_url: Option<&str>,
+    approved_models: &serde_json::Value,
+    default_model: Option<&str>,
+    updated_by: Uuid,
+) -> Result<LlmProviderSettingsRow, sqlx::Error> {
+    sqlx::query_as::<_, LlmProviderSettingsRow>(
+        "INSERT INTO llm_provider_settings (provider, enabled, base_url, approved_models, default_model, updated_at, updated_by) \
+         VALUES ($1, $2, $3, $4, $5, now(), $6) \
+         ON CONFLICT (provider) DO UPDATE SET \
+            enabled = EXCLUDED.enabled, \
+            base_url = EXCLUDED.base_url, \
+            approved_models = EXCLUDED.approved_models, \
+            default_model = EXCLUDED.default_model, \
+            updated_at = now(), \
+            updated_by = EXCLUDED.updated_by \
+         RETURNING provider, enabled, base_url, approved_models, default_model, updated_at, updated_by",
+    )
+    .bind(provider)
+    .bind(enabled)
+    .bind(base_url)
+    .bind(approved_models)
+    .bind(default_model)
+    .bind(updated_by)
+    .fetch_one(pool)
+    .await
+}

--- a/crates/sao-server/src/db/mod.rs
+++ b/crates/sao-server/src/db/mod.rs
@@ -1,9 +1,12 @@
 pub mod admin;
 pub mod admin_entity;
+pub mod agent_tokens;
 pub mod agents;
 pub mod audit;
+pub mod llm_providers;
 pub mod migrate;
 pub mod oidc;
+pub mod orion;
 pub mod pool;
 pub mod sessions;
 pub mod skills;

--- a/crates/sao-server/src/db/orion.rs
+++ b/crates/sao-server/src/db/orion.rs
@@ -1,0 +1,68 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Debug, sqlx::FromRow, serde::Serialize)]
+pub struct EgressEventRow {
+    pub event_id: Uuid,
+    pub user_id: Uuid,
+    pub agent_id: Option<Uuid>,
+    pub orion_id: Uuid,
+    pub event_type: String,
+    pub payload: serde_json::Value,
+    pub enqueued_at: DateTime<Utc>,
+    pub attempts: i32,
+    pub created_at: DateTime<Utc>,
+}
+
+pub async fn list_for_agent(
+    pool: &PgPool,
+    agent_id: Uuid,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<EgressEventRow>, sqlx::Error> {
+    sqlx::query_as::<_, EgressEventRow>(
+        "SELECT event_id, user_id, agent_id, orion_id, event_type, payload, enqueued_at, attempts, created_at \
+         FROM orion_egress_events \
+         WHERE agent_id = $1 \
+         ORDER BY created_at DESC \
+         LIMIT $2 OFFSET $3",
+    )
+    .bind(agent_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_egress_event_if_new(
+    pool: &PgPool,
+    event_id: Uuid,
+    user_id: Uuid,
+    agent_id: Option<Uuid>,
+    orion_id: Uuid,
+    event_type: &str,
+    payload: serde_json::Value,
+    enqueued_at: DateTime<Utc>,
+    attempts: u32,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query(
+        "INSERT INTO orion_egress_events \
+         (event_id, user_id, agent_id, orion_id, event_type, payload, enqueued_at, attempts) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \
+         ON CONFLICT (event_id) DO NOTHING",
+    )
+    .bind(event_id)
+    .bind(user_id)
+    .bind(agent_id)
+    .bind(orion_id)
+    .bind(event_type)
+    .bind(payload)
+    .bind(enqueued_at)
+    .bind(attempts as i32)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}

--- a/crates/sao-server/src/db/skills.rs
+++ b/crates/sao-server/src/db/skills.rs
@@ -360,10 +360,7 @@ pub struct NewSkillReview {
     pub notes: Option<String>,
 }
 
-pub async fn insert_review(
-    pool: &PgPool,
-    review: NewSkillReview,
-) -> Result<i64, sqlx::Error> {
+pub async fn insert_review(pool: &PgPool, review: NewSkillReview) -> Result<i64, sqlx::Error> {
     let row: (i64,) = sqlx::query_as(
         "INSERT INTO skill_reviews \
          (target_type, target_id, action, reviewer_user_id, policy_score, policy_details, notes) \
@@ -394,4 +391,3 @@ pub async fn list_reviews_for_target(
     .fetch_all(pool)
     .await
 }
-

--- a/crates/sao-server/src/db/vault_key.rs
+++ b/crates/sao-server/src/db/vault_key.rs
@@ -28,3 +28,27 @@ pub async fn get_vmk(pool: &PgPool) -> Result<Option<VaultMasterKeyRow>, sqlx::E
     .fetch_optional(pool)
     .await
 }
+
+/// Store the initial sealed VMK envelope.
+pub async fn insert_vmk(
+    pool: &PgPool,
+    encrypted_key: &[u8],
+    kdf_salt: &[u8],
+    kdf_memory_cost: i32,
+    kdf_time_cost: i32,
+    kdf_parallelism: i32,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO vault_master_key \
+         (encrypted_key, kdf_salt, kdf_memory_cost, kdf_time_cost, kdf_parallelism) \
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(encrypted_key)
+    .bind(kdf_salt)
+    .bind(kdf_memory_cost)
+    .bind(kdf_time_cost)
+    .bind(kdf_parallelism)
+    .execute(pool)
+    .await?;
+    Ok(())
+}

--- a/crates/sao-server/src/llm/anthropic.rs
+++ b/crates/sao-server/src/llm/anthropic.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+
+use super::{GenerateRequest, LlmError};
+
+#[derive(Serialize)]
+struct MessagesRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    temperature: f32,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    system: &'a str,
+    messages: Vec<Message<'a>>,
+}
+
+#[derive(Serialize)]
+struct Message<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct MessagesResponse {
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Deserialize)]
+struct ContentBlock {
+    #[serde(rename = "type")]
+    kind: String,
+    text: Option<String>,
+}
+
+pub async fn generate(api_key: &str, req: &GenerateRequest) -> Result<String, LlmError> {
+    let body = MessagesRequest {
+        model: &req.model,
+        max_tokens: 1024,
+        temperature: req.temperature,
+        system: &req.system,
+        messages: vec![Message {
+            role: "user",
+            content: &req.prompt,
+        }],
+    };
+
+    let resp = reqwest::Client::new()
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(LlmError::ProviderError {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+
+    let parsed: MessagesResponse =
+        serde_json::from_str(&text).map_err(|e| LlmError::BadResponse(e.to_string()))?;
+
+    parsed
+        .content
+        .into_iter()
+        .find(|b| b.kind == "text")
+        .and_then(|b| b.text)
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| LlmError::BadResponse("no text content in response".into()))
+}

--- a/crates/sao-server/src/llm/gemini.rs
+++ b/crates/sao-server/src/llm/gemini.rs
@@ -1,0 +1,121 @@
+//! Google Gemini — Generative Language API (v1beta generateContent).
+
+use serde::{Deserialize, Serialize};
+
+use super::{GenerateRequest, LlmError};
+
+#[derive(Serialize)]
+struct GenerateContentRequest<'a> {
+    contents: Vec<Content<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_instruction: Option<Content<'a>>,
+    generation_config: GenerationConfig,
+}
+
+#[derive(Serialize)]
+struct Content<'a> {
+    role: &'a str,
+    parts: Vec<Part<'a>>,
+}
+
+#[derive(Serialize)]
+struct Part<'a> {
+    text: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GenerationConfig {
+    temperature: f32,
+    max_output_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct GenerateContentResponse {
+    candidates: Option<Vec<Candidate>>,
+    #[serde(rename = "promptFeedback")]
+    prompt_feedback: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct Candidate {
+    content: Option<CandidateContent>,
+}
+
+#[derive(Deserialize)]
+struct CandidateContent {
+    parts: Option<Vec<CandidatePart>>,
+}
+
+#[derive(Deserialize)]
+struct CandidatePart {
+    text: Option<String>,
+}
+
+pub async fn generate(api_key: &str, req: &GenerateRequest) -> Result<String, LlmError> {
+    let url = format!(
+        "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
+        req.model, api_key
+    );
+
+    let system_instruction = if req.system.trim().is_empty() {
+        None
+    } else {
+        Some(Content {
+            role: "system",
+            parts: vec![Part { text: &req.system }],
+        })
+    };
+
+    let body = GenerateContentRequest {
+        contents: vec![Content {
+            role: "user",
+            parts: vec![Part { text: &req.prompt }],
+        }],
+        system_instruction,
+        generation_config: GenerationConfig {
+            temperature: req.temperature,
+            max_output_tokens: 1024,
+        },
+    };
+
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(LlmError::ProviderError {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+
+    let parsed: GenerateContentResponse =
+        serde_json::from_str(&text).map_err(|e| LlmError::BadResponse(e.to_string()))?;
+
+    if parsed.candidates.as_ref().map(|c| c.is_empty()).unwrap_or(true) {
+        let reason = parsed
+            .prompt_feedback
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "no candidates".to_string());
+        return Err(LlmError::BadResponse(format!("Gemini returned no candidates: {reason}")));
+    }
+
+    parsed
+        .candidates
+        .and_then(|cands| cands.into_iter().next())
+        .and_then(|c| c.content)
+        .and_then(|c| c.parts)
+        .and_then(|parts| parts.into_iter().filter_map(|p| p.text).next())
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| LlmError::BadResponse("Gemini candidate had no text part".into()))
+}

--- a/crates/sao-server/src/llm/grok.rs
+++ b/crates/sao-server/src/llm/grok.rs
@@ -1,0 +1,91 @@
+//! xAI Grok — OpenAI-compatible chat completions at api.x.ai.
+
+use serde::{Deserialize, Serialize};
+
+use super::{GenerateRequest, LlmError};
+
+#[derive(Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<Message<'a>>,
+    temperature: f32,
+}
+
+#[derive(Serialize)]
+struct Message<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: ResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct ResponseMessage {
+    content: Option<String>,
+}
+
+pub async fn generate(api_key: &str, req: &GenerateRequest) -> Result<String, LlmError> {
+    let messages = if req.system.trim().is_empty() {
+        vec![Message {
+            role: "user",
+            content: &req.prompt,
+        }]
+    } else {
+        vec![
+            Message {
+                role: "system",
+                content: &req.system,
+            },
+            Message {
+                role: "user",
+                content: &req.prompt,
+            },
+        ]
+    };
+
+    let body = ChatRequest {
+        model: &req.model,
+        messages,
+        temperature: req.temperature,
+    };
+
+    let resp = reqwest::Client::new()
+        .post("https://api.x.ai/v1/chat/completions")
+        .bearer_auth(api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(LlmError::ProviderError {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+
+    let parsed: ChatResponse =
+        serde_json::from_str(&text).map_err(|e| LlmError::BadResponse(e.to_string()))?;
+
+    parsed
+        .choices
+        .into_iter()
+        .next()
+        .and_then(|c| c.message.content)
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| LlmError::BadResponse("no choices in response".into()))
+}

--- a/crates/sao-server/src/llm/keys.rs
+++ b/crates/sao-server/src/llm/keys.rs
@@ -1,0 +1,31 @@
+//! Vault lookups for LLM provider API keys.
+//!
+//! Keys are stored in `vault_secrets` with `provider = '<openai|anthropic>'`, `label = 'api_key'`,
+//! `secret_type = 'api_key'`. The vault must be unsealed for reads.
+
+use crate::state::AppState;
+
+use super::LlmError;
+
+pub async fn get_api_key(state: &AppState, provider: &str) -> Result<Option<String>, LlmError> {
+    let row = sqlx::query_as::<_, (Vec<u8>, Vec<u8>)>(
+        "SELECT ciphertext, nonce FROM vault_secrets \
+         WHERE provider = $1 AND label = 'api_key' AND secret_type = 'api_key' \
+         ORDER BY updated_at DESC LIMIT 1",
+    )
+    .bind(provider)
+    .fetch_optional(&state.inner.db)
+    .await?;
+
+    let Some((ciphertext, nonce)) = row else {
+        return Ok(None);
+    };
+
+    let vs = state.inner.vault_state.read().await;
+    let vmk = vs.vmk().ok_or(LlmError::VaultSealed)?;
+    let plaintext = vmk
+        .decrypt(&ciphertext, &nonce)
+        .map_err(|e| LlmError::BadResponse(format!("vault decrypt: {e}")))?;
+
+    Ok(Some(String::from_utf8_lossy(&plaintext).to_string()))
+}

--- a/crates/sao-server/src/llm/mod.rs
+++ b/crates/sao-server/src/llm/mod.rs
@@ -1,0 +1,126 @@
+//! SAO-hosted LLM proxy. OrionII entities call POST /api/llm/generate; SAO holds the keys
+//! and forwards to the configured provider. Keys never leave the server, calls are auditable,
+//! revocation of an entity token instantly cuts off model access.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::state::AppState;
+
+pub mod anthropic;
+pub mod gemini;
+pub mod grok;
+pub mod keys;
+pub mod ollama;
+pub mod openai;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GenerateRequest {
+    pub provider: String,
+    pub model: String,
+    #[serde(default)]
+    pub system: String,
+    pub prompt: String,
+    #[serde(default = "default_temperature")]
+    pub temperature: f32,
+    #[serde(default)]
+    pub role: String,
+}
+
+fn default_temperature() -> f32 {
+    0.2
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GenerateResponse {
+    pub text: String,
+    pub model: String,
+    pub latency_ms: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum LlmError {
+    #[error("provider {0} is not enabled")]
+    ProviderDisabled(String),
+    #[error("provider {0} is not configured (missing base_url or api key)")]
+    ProviderUnconfigured(String),
+    #[error("model {model} is not on the approved list for {provider}")]
+    ModelNotApproved { provider: String, model: String },
+    #[error("vault is sealed; cannot read provider key")]
+    VaultSealed,
+    #[error("provider HTTP call failed: {0}")]
+    Http(String),
+    #[error("provider returned an unparseable response: {0}")]
+    BadResponse(String),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("provider returned error status {status}: {body}")]
+    ProviderError { status: u16, body: String },
+}
+
+pub async fn dispatch(
+    state: &AppState,
+    req: &GenerateRequest,
+) -> Result<GenerateResponse, LlmError> {
+    let settings = crate::db::llm_providers::get(&state.inner.db, &req.provider)
+        .await?
+        .ok_or_else(|| LlmError::ProviderUnconfigured(req.provider.clone()))?;
+
+    if !settings.enabled {
+        return Err(LlmError::ProviderDisabled(req.provider.clone()));
+    }
+
+    let approved: Vec<String> = serde_json::from_value(settings.approved_models.clone())
+        .unwrap_or_default();
+    if !approved.is_empty() && !approved.iter().any(|m| m == &req.model) {
+        return Err(LlmError::ModelNotApproved {
+            provider: req.provider.clone(),
+            model: req.model.clone(),
+        });
+    }
+
+    let started = std::time::Instant::now();
+    let text = match req.provider.as_str() {
+        "ollama" => {
+            let base = settings
+                .base_url
+                .clone()
+                .ok_or_else(|| LlmError::ProviderUnconfigured("ollama".into()))?;
+            ollama::generate(&base, req).await?
+        }
+        "openai" => {
+            let key = keys::get_api_key(state, "openai")
+                .await?
+                .ok_or_else(|| LlmError::ProviderUnconfigured("openai".into()))?;
+            openai::generate(&key, req).await?
+        }
+        "anthropic" => {
+            let key = keys::get_api_key(state, "anthropic")
+                .await?
+                .ok_or_else(|| LlmError::ProviderUnconfigured("anthropic".into()))?;
+            anthropic::generate(&key, req).await?
+        }
+        "grok" => {
+            let key = keys::get_api_key(state, "grok")
+                .await?
+                .ok_or_else(|| LlmError::ProviderUnconfigured("grok".into()))?;
+            grok::generate(&key, req).await?
+        }
+        "gemini" => {
+            let key = keys::get_api_key(state, "gemini")
+                .await?
+                .ok_or_else(|| LlmError::ProviderUnconfigured("gemini".into()))?;
+            gemini::generate(&key, req).await?
+        }
+        other => {
+            return Err(LlmError::ProviderUnconfigured(other.to_string()));
+        }
+    };
+    let latency_ms = started.elapsed().as_millis() as u64;
+
+    Ok(GenerateResponse {
+        text,
+        model: req.model.clone(),
+        latency_ms,
+    })
+}

--- a/crates/sao-server/src/llm/ollama.rs
+++ b/crates/sao-server/src/llm/ollama.rs
@@ -1,0 +1,105 @@
+use serde::{Deserialize, Serialize};
+
+use super::{GenerateRequest, LlmError};
+
+#[derive(Serialize)]
+struct OllamaGenerateBody<'a> {
+    model: &'a str,
+    system: &'a str,
+    prompt: &'a str,
+    stream: bool,
+    options: Options,
+}
+
+#[derive(Serialize)]
+struct Options {
+    temperature: f32,
+}
+
+#[derive(Deserialize)]
+struct OllamaGenerateResponse {
+    response: Option<String>,
+    error: Option<String>,
+}
+
+pub async fn generate(base_url: &str, req: &GenerateRequest) -> Result<String, LlmError> {
+    let url = format!("{}/api/generate", base_url.trim_end_matches('/'));
+    let body = OllamaGenerateBody {
+        model: &req.model,
+        system: &req.system,
+        prompt: &req.prompt,
+        stream: false,
+        options: Options {
+            temperature: req.temperature,
+        },
+    };
+
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(LlmError::ProviderError {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+
+    let parsed: OllamaGenerateResponse =
+        serde_json::from_str(&text).map_err(|e| LlmError::BadResponse(e.to_string()))?;
+
+    if let Some(err) = parsed.error {
+        return Err(LlmError::BadResponse(err));
+    }
+
+    parsed
+        .response
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| LlmError::BadResponse("empty response field".into()))
+}
+
+pub async fn list_models(base_url: &str) -> Result<Vec<String>, LlmError> {
+    #[derive(Deserialize)]
+    struct TagsResp {
+        models: Option<Vec<TagsEntry>>,
+    }
+    #[derive(Deserialize)]
+    struct TagsEntry {
+        name: String,
+    }
+
+    let url = format!("{}/api/tags", base_url.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+    if !status.is_success() {
+        return Err(LlmError::ProviderError {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+    let parsed: TagsResp =
+        serde_json::from_str(&text).map_err(|e| LlmError::BadResponse(e.to_string()))?;
+    Ok(parsed
+        .models
+        .unwrap_or_default()
+        .into_iter()
+        .map(|e| e.name)
+        .collect())
+}

--- a/crates/sao-server/src/llm/openai.rs
+++ b/crates/sao-server/src/llm/openai.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+
+use super::{GenerateRequest, LlmError};
+
+#[derive(Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<Message<'a>>,
+    temperature: f32,
+}
+
+#[derive(Serialize)]
+struct Message<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: ResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct ResponseMessage {
+    content: Option<String>,
+}
+
+pub async fn generate(api_key: &str, req: &GenerateRequest) -> Result<String, LlmError> {
+    let messages = if req.system.trim().is_empty() {
+        vec![Message {
+            role: "user",
+            content: &req.prompt,
+        }]
+    } else {
+        vec![
+            Message {
+                role: "system",
+                content: &req.system,
+            },
+            Message {
+                role: "user",
+                content: &req.prompt,
+            },
+        ]
+    };
+
+    let body = ChatRequest {
+        model: &req.model,
+        messages,
+        temperature: req.temperature,
+    };
+
+    let resp = reqwest::Client::new()
+        .post("https://api.openai.com/v1/chat/completions")
+        .bearer_auth(api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| LlmError::Http(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(LlmError::ProviderError {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+
+    let parsed: ChatResponse =
+        serde_json::from_str(&text).map_err(|e| LlmError::BadResponse(e.to_string()))?;
+
+    parsed
+        .choices
+        .into_iter()
+        .next()
+        .and_then(|c| c.message.content)
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| LlmError::BadResponse("no choices in response".into()))
+}

--- a/crates/sao-server/src/main.rs
+++ b/crates/sao-server/src/main.rs
@@ -1,13 +1,15 @@
 mod auth;
 mod db;
+mod llm;
 mod routes;
 mod security;
 mod state;
 mod vault_state;
 
 use anyhow::{bail, Context};
-use axum::Router;
 use axum::middleware;
+use axum::Router;
+use serde_json::json;
 use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 use tracing_subscriber::EnvFilter;
@@ -20,12 +22,168 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
+    match std::env::args().nth(1).as_deref() {
+        Some("bootstrap-local") => return run_local_bootstrap().await,
+        Some("mint-dev-token") => return mint_dev_token().await,
+        _ => {}
+    }
+
     if let Err(error) = run_server().await {
         tracing::error!("SAO server startup failed: {error:#}");
         return Err(error);
     }
 
     Ok(())
+}
+
+async fn mint_dev_token() -> anyhow::Result<()> {
+    require_local_bootstrap_enabled()?;
+    let username = std::env::var("SAO_LOCAL_ADMIN_USERNAME")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "local-admin".to_string());
+    let pool = db::pool::init_pool()
+        .await
+        .context("Failed to initialize the PostgreSQL connection pool")?;
+    let user = db::users::get_user_by_username(&pool, &username)
+        .await
+        .context("Failed to query local admin user")?
+        .with_context(|| {
+            format!("Local user {username} was not found; run bootstrap-local first")
+        })?;
+    let jwt_secret = auth::session::jwt_secret();
+    let token =
+        auth::session::create_access_token(user.id, &user.username, &user.role, &jwt_secret)
+            .context("Failed to create local development bearer token")?;
+    println!("{token}");
+    Ok(())
+}
+
+async fn run_local_bootstrap() -> anyhow::Result<()> {
+    require_local_bootstrap_enabled()?;
+    tracing::info!("Starting SAO local development bootstrap");
+
+    let pool = db::pool::init_pool()
+        .await
+        .context("Failed to initialize the PostgreSQL connection pool")?;
+    db::migrate::run_migrations(&pool)
+        .await
+        .context("Failed while applying database migrations")?;
+
+    let passphrase = required_env("SAO_LOCAL_VAULT_PASSPHRASE")?;
+    let username = std::env::var("SAO_LOCAL_ADMIN_USERNAME")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "local-admin".to_string());
+    let display_name = std::env::var("SAO_LOCAL_ADMIN_DISPLAY_NAME")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "Local SAO Admin".to_string());
+
+    let vault_initialized = db::vault_key::vmk_exists(&pool)
+        .await
+        .context("Failed to inspect vault master key state")?;
+    if !vault_initialized {
+        initialize_local_vault(&pool, &passphrase).await?;
+        tracing::info!("Initialized local development vault");
+    } else {
+        tracing::info!("Local development vault already initialized");
+    }
+
+    let user_id = match db::users::get_user_by_username(&pool, &username)
+        .await
+        .context("Failed to inspect local admin user")?
+    {
+        Some(user) => {
+            if user.role != "admin" {
+                db::users::update_user_role(&pool, user.id, "admin")
+                    .await
+                    .context("Failed to promote local bootstrap user to admin")?;
+            }
+            user.id
+        }
+        None => db::users::create_user(&pool, &username, Some(&display_name), "admin")
+            .await
+            .context("Failed to create local bootstrap admin user")?,
+    };
+
+    let _ = db::audit::insert_audit_log(
+        &pool,
+        Some(user_id),
+        None,
+        "local.bootstrap",
+        Some("setup"),
+        Some(json!({
+            "username": username,
+            "vault_initialized": !vault_initialized,
+            "mode": "local_development",
+        })),
+        None,
+        Some("sao-server bootstrap-local"),
+    )
+    .await;
+
+    println!("SAO local bootstrap complete.");
+    println!("Admin user: {username}");
+    println!("Vault: initialized");
+    println!("Next: open http://localhost:3100 or register a WebAuthn credential for {username}.");
+    Ok(())
+}
+
+async fn initialize_local_vault(pool: &sqlx::PgPool, passphrase: &str) -> anyhow::Result<()> {
+    let vmk = sao_core::vault::VaultMasterKey::generate();
+    let salt = sao_core::vault::generate_salt();
+    let passphrase_key = sao_core::vault::derive_key_from_passphrase(
+        passphrase,
+        &salt,
+        sao_core::vault::kdf::DEFAULT_MEMORY_COST,
+        sao_core::vault::kdf::DEFAULT_TIME_COST,
+        sao_core::vault::kdf::DEFAULT_PARALLELISM,
+    )
+    .map_err(|error| anyhow::anyhow!("Failed to derive local vault passphrase key: {error}"))?;
+    let (sealed, nonce) = vmk
+        .seal(&passphrase_key)
+        .map_err(|error| anyhow::anyhow!("Failed to seal local vault master key: {error}"))?;
+    let mut envelope = sealed;
+    envelope.extend_from_slice(&nonce);
+
+    db::vault_key::insert_vmk(
+        pool,
+        &envelope,
+        &salt,
+        sao_core::vault::kdf::DEFAULT_MEMORY_COST as i32,
+        sao_core::vault::kdf::DEFAULT_TIME_COST as i32,
+        sao_core::vault::kdf::DEFAULT_PARALLELISM as i32,
+    )
+    .await
+    .context("Failed to store local vault master key envelope")
+}
+
+fn require_local_bootstrap_enabled() -> anyhow::Result<()> {
+    let enabled = std::env::var("SAO_LOCAL_BOOTSTRAP")
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes"
+            )
+        })
+        .unwrap_or(false);
+    if !enabled {
+        bail!("Refusing local bootstrap unless SAO_LOCAL_BOOTSTRAP=true is set");
+    }
+    Ok(())
+}
+
+fn required_env(name: &str) -> anyhow::Result<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .with_context(|| format!("{name} must be set for local bootstrap"))
 }
 
 async fn run_server() -> anyhow::Result<()> {
@@ -76,6 +234,7 @@ async fn run_server() -> anyhow::Result<()> {
         .allow_headers(AllowHeaders::list([
             axum::http::header::CONTENT_TYPE,
             axum::http::header::ACCEPT,
+            axum::http::header::AUTHORIZATION,
             axum::http::header::COOKIE,
             axum::http::header::SET_COOKIE,
             axum::http::HeaderName::from_static(security::CSRF_HEADER),

--- a/crates/sao-server/src/routes/admin.rs
+++ b/crates/sao-server/src/routes/admin.rs
@@ -15,21 +15,36 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         // User management (admin only)
         .route("/api/admin/users", get(list_users))
-        .route("/api/admin/users/{id}/role", put(update_user_role))
-        .route("/api/admin/users/{id}", delete(delete_user))
+        .route("/api/admin/users/:id/role", put(update_user_role))
+        .route("/api/admin/users/:id", delete(delete_user))
         // OIDC provider management (admin only)
         .route("/api/admin/oidc/providers", post(create_oidc_provider))
         .route("/api/admin/oidc/providers", get(list_oidc_providers))
-        .route("/api/admin/oidc/providers/{id}", put(update_oidc_provider))
+        .route("/api/admin/oidc/providers/:id", put(update_oidc_provider))
         .route(
-            "/api/admin/oidc/providers/{id}",
+            "/api/admin/oidc/providers/:id",
             delete(delete_oidc_provider),
         )
         // SAO admin entity overview (admin only)
         .route("/api/admin/admin-entity", get(get_admin_entity_overview))
         // Audit log (admin only)
         .route("/api/admin/audit", get(query_audit_log))
+        // LLM provider configuration (admin only)
+        .route("/api/admin/llm-providers", get(list_llm_providers))
+        .route("/api/admin/llm-providers/:provider", put(update_llm_provider))
+        .route(
+            "/api/admin/llm-providers/ollama/probe",
+            post(probe_ollama_models),
+        )
+        .route(
+            "/api/admin/llm-providers/:provider/test",
+            post(test_llm_provider),
+        )
 }
+
+const SUPPORTED_PROVIDERS: &[&str] =
+    &["openai", "anthropic", "ollama", "grok", "gemini"];
+const KEY_BEARING_PROVIDERS: &[&str] = &["openai", "anthropic", "grok", "gemini"];
 
 // --- User management ---
 
@@ -388,6 +403,355 @@ async fn get_admin_entity_overview(
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+// --- LLM provider configuration ---
+
+async fn list_llm_providers(
+    AdminUser(_admin): AdminUser,
+    State(state): State<AppState>,
+) -> (StatusCode, Json<Value>) {
+    let rows = match crate::db::llm_providers::list(&state.inner.db).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    // Surface "key present" without revealing the key itself.
+    let with_key_status: Vec<Value> = {
+        let mut out = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let has_api_key = matches!(
+                sqlx::query_scalar::<_, i64>(
+                    "SELECT count(*)::bigint FROM vault_secrets \
+                     WHERE provider = $1 AND label = 'api_key' AND secret_type = 'api_key'",
+                )
+                .bind(&row.provider)
+                .fetch_one(&state.inner.db)
+                .await,
+                Ok(count) if count > 0
+            );
+            out.push(json!({
+                "provider": row.provider,
+                "enabled": row.enabled,
+                "base_url": row.base_url,
+                "approved_models": row.approved_models,
+                "default_model": row.default_model,
+                "updated_at": row.updated_at,
+                "has_api_key": has_api_key,
+            }));
+        }
+        out
+    };
+
+    (
+        StatusCode::OK,
+        Json(json!({ "providers": with_key_status })),
+    )
+}
+
+#[derive(Deserialize)]
+struct UpdateLlmProviderRequest {
+    #[serde(default)]
+    enabled: bool,
+    #[serde(default)]
+    base_url: Option<String>,
+    #[serde(default)]
+    approved_models: Option<serde_json::Value>,
+    #[serde(default)]
+    default_model: Option<String>,
+    /// If present, replaces the API key in the vault. Never returned by GET.
+    #[serde(default)]
+    api_key: Option<String>,
+}
+
+async fn update_llm_provider(
+    AdminUser(admin): AdminUser,
+    State(state): State<AppState>,
+    Path(provider): Path<String>,
+    Json(req): Json<UpdateLlmProviderRequest>,
+) -> (StatusCode, Json<Value>) {
+    if !SUPPORTED_PROVIDERS.contains(&provider.as_str()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Unknown provider" })),
+        );
+    }
+
+    if provider == "ollama" && req.enabled && req.base_url.as_deref().unwrap_or("").trim().is_empty()
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Ollama requires a base_url when enabled" })),
+        );
+    }
+
+    // If an API key was supplied, store it in the vault under (provider, label='api_key').
+    if let Some(api_key) = req.api_key.as_deref() {
+        if !KEY_BEARING_PROVIDERS.contains(&provider.as_str()) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("{} does not require an api_key", provider) })),
+            );
+        }
+        let vs = state.inner.vault_state.read().await;
+        let Some(vmk) = vs.vmk() else {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "Vault is sealed" })),
+            );
+        };
+        let (ciphertext, nonce) = match vmk.encrypt(api_key.trim().as_bytes()) {
+            Ok(out) => out,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": format!("Encryption failed: {}", e) })),
+                );
+            }
+        };
+        // Replace any previous key for this provider.
+        let _ = sqlx::query(
+            "DELETE FROM vault_secrets \
+             WHERE provider = $1 AND label = 'api_key' AND secret_type = 'api_key'",
+        )
+        .bind(&provider)
+        .execute(&state.inner.db)
+        .await;
+        if let Err(e) = crate::db::vault::create_secret(
+            &state.inner.db,
+            None,
+            "api_key",
+            "api_key",
+            Some(&provider),
+            &ciphertext,
+            &nonce,
+            Some(json!({ "kind": "llm_provider_api_key" })),
+        )
+        .await
+        {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    }
+
+    let approved_models = req
+        .approved_models
+        .clone()
+        .unwrap_or_else(|| json!([]));
+
+    let saved = match crate::db::llm_providers::upsert(
+        &state.inner.db,
+        &provider,
+        req.enabled,
+        req.base_url.as_deref(),
+        &approved_models,
+        req.default_model.as_deref(),
+        admin.user_id,
+    )
+    .await
+    {
+        Ok(row) => row,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(admin.user_id),
+        None,
+        "admin.llm_providers.update",
+        Some("llm_provider"),
+        Some(json!({
+            "provider": provider,
+            "enabled": req.enabled,
+            "default_model": req.default_model,
+            "set_api_key": req.api_key.is_some(),
+        })),
+        None,
+        None,
+    )
+    .await;
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "provider": saved.provider,
+            "enabled": saved.enabled,
+            "base_url": saved.base_url,
+            "approved_models": saved.approved_models,
+            "default_model": saved.default_model,
+            "updated_at": saved.updated_at,
+        })),
+    )
+}
+
+#[derive(Deserialize)]
+struct ProbeOllamaRequest {
+    base_url: String,
+}
+
+async fn probe_ollama_models(
+    AdminUser(_admin): AdminUser,
+    Json(req): Json<ProbeOllamaRequest>,
+) -> (StatusCode, Json<Value>) {
+    if req.base_url.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "base_url is required" })),
+        );
+    }
+
+    match crate::llm::ollama::list_models(req.base_url.trim()).await {
+        Ok(models) => (StatusCode::OK, Json(json!({ "models": models }))),
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+#[derive(Deserialize, Default)]
+struct TestProviderRequest {
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
+}
+
+async fn test_llm_provider(
+    AdminUser(admin): AdminUser,
+    State(state): State<AppState>,
+    Path(provider): Path<String>,
+    Json(req): Json<TestProviderRequest>,
+) -> (StatusCode, Json<Value>) {
+    if !SUPPORTED_PROVIDERS.contains(&provider.as_str()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Unknown provider" })),
+        );
+    }
+
+    let settings = match crate::db::llm_providers::get(&state.inner.db, &provider).await {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "Provider is not registered" })),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    let model = req
+        .model
+        .clone()
+        .or_else(|| settings.default_model.clone())
+        .unwrap_or_default();
+    if model.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "No model specified and no default_model set" })),
+        );
+    }
+
+    // Bypass approved-model gate on test calls so admins can probe new models before saving them.
+    let test_req = crate::llm::GenerateRequest {
+        provider: provider.clone(),
+        model: model.clone(),
+        system: "You are a connectivity test for SAO. Reply briefly.".to_string(),
+        prompt: req
+            .prompt
+            .clone()
+            .unwrap_or_else(|| "ping".to_string()),
+        temperature: 0.0,
+        role: "test".to_string(),
+    };
+
+    let started = std::time::Instant::now();
+    let result = match provider.as_str() {
+        "ollama" => match settings.base_url.clone() {
+            Some(url) => crate::llm::ollama::generate(&url, &test_req).await,
+            None => Err(crate::llm::LlmError::ProviderUnconfigured("ollama".into())),
+        },
+        "openai" => match crate::llm::keys::get_api_key(&state, "openai").await {
+            Ok(Some(key)) => crate::llm::openai::generate(&key, &test_req).await,
+            Ok(None) => Err(crate::llm::LlmError::ProviderUnconfigured("openai".into())),
+            Err(e) => Err(e),
+        },
+        "anthropic" => match crate::llm::keys::get_api_key(&state, "anthropic").await {
+            Ok(Some(key)) => crate::llm::anthropic::generate(&key, &test_req).await,
+            Ok(None) => Err(crate::llm::LlmError::ProviderUnconfigured("anthropic".into())),
+            Err(e) => Err(e),
+        },
+        "grok" => match crate::llm::keys::get_api_key(&state, "grok").await {
+            Ok(Some(key)) => crate::llm::grok::generate(&key, &test_req).await,
+            Ok(None) => Err(crate::llm::LlmError::ProviderUnconfigured("grok".into())),
+            Err(e) => Err(e),
+        },
+        "gemini" => match crate::llm::keys::get_api_key(&state, "gemini").await {
+            Ok(Some(key)) => crate::llm::gemini::generate(&key, &test_req).await,
+            Ok(None) => Err(crate::llm::LlmError::ProviderUnconfigured("gemini".into())),
+            Err(e) => Err(e),
+        },
+        _ => unreachable!("provider validated above"),
+    };
+    let latency_ms = started.elapsed().as_millis() as u64;
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(admin.user_id),
+        None,
+        "admin.llm_providers.test",
+        Some("llm_provider"),
+        Some(json!({
+            "provider": provider,
+            "model": model,
+            "ok": result.is_ok(),
+            "latency_ms": latency_ms,
+        })),
+        None,
+        None,
+    )
+    .await;
+
+    match result {
+        Ok(text) => (
+            StatusCode::OK,
+            Json(json!({
+                "ok": true,
+                "provider": provider,
+                "model": model,
+                "latency_ms": latency_ms,
+                "preview": text.chars().take(240).collect::<String>(),
+            })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({
+                "ok": false,
+                "provider": provider,
+                "model": model,
+                "latency_ms": latency_ms,
+                "error": e.to_string(),
+            })),
         ),
     }
 }

--- a/crates/sao-server/src/routes/agents.rs
+++ b/crates/sao-server/src/routes/agents.rs
@@ -1,7 +1,7 @@
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
-    routing::{delete, get, post},
+    routing::{get, post},
     Json, Router,
 };
 use serde::Deserialize;
@@ -16,8 +16,17 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/agents", get(list_agents))
         .route("/api/agents", post(create_agent))
-        .route("/api/agents/{id}", get(get_agent_status))
-        .route("/api/agents/{id}", delete(delete_agent_handler))
+        .route(
+            "/api/agents/:id/delete",
+            post(delete_agent_handler).delete(delete_agent_handler),
+        )
+        .route(
+            "/api/agents/:id",
+            get(get_agent_status)
+                .delete(delete_agent_handler)
+                .post(delete_agent_handler),
+        )
+        .route("/api/agents/:id/events", get(list_agent_events))
 }
 
 async fn list_agents(user: AuthUser, State(state): State<AppState>) -> (StatusCode, Json<Value>) {
@@ -42,6 +51,12 @@ struct CreateAgentRequest {
     agent_type: Option<String>,
     #[serde(default)]
     pubkey: Option<String>,
+    #[serde(default)]
+    default_provider: Option<String>,
+    #[serde(default)]
+    default_id_model: Option<String>,
+    #[serde(default)]
+    default_ego_model: Option<String>,
 }
 
 async fn create_agent(
@@ -58,8 +73,7 @@ async fn create_agent(
         );
     }
 
-    let (identity_agent_id, agent_dir) = match state.inner.identity_manager.create_agent(name)
-    {
+    let (identity_agent_id, agent_dir) = match state.inner.identity_manager.create_agent(name) {
         Ok(result) => result,
         Err(e) => {
             return (
@@ -87,7 +101,16 @@ async fn create_agent(
         );
     }
 
-    match crate::db::agents::create_agent(&state.inner.db, user.user_id, name).await {
+    match crate::db::agents::create_agent(
+        &state.inner.db,
+        user.user_id,
+        name,
+        req.default_provider.as_deref(),
+        req.default_id_model.as_deref(),
+        req.default_ego_model.as_deref(),
+    )
+    .await
+    {
         Ok(_agent) => {
             let _ = crate::db::audit::insert_audit_log(
                 &state.inner.db,
@@ -160,6 +183,11 @@ async fn get_agent_status(
         );
     }
 
+    let last_heartbeat = crate::db::agents::last_egress_at(&state.inner.db, id)
+        .await
+        .ok()
+        .flatten();
+
     (
         StatusCode::OK,
         Json(json!({
@@ -168,7 +196,10 @@ async fn get_agent_status(
             "documents": ["soul.md", "ethics.md", "org-map.md", "personality.md"],
             "soul_immutable": true,
             "personality_preview": "ego traits (editable by Superego only)",
-            "last_heartbeat": "just now"
+            "default_provider": agent.default_provider,
+            "default_id_model": agent.default_id_model,
+            "default_ego_model": agent.default_ego_model,
+            "last_heartbeat": last_heartbeat,
         })),
     )
 }
@@ -201,6 +232,10 @@ async fn delete_agent_handler(
         );
     }
 
+    let revoked_tokens = crate::auth::agent_tokens::revoke_for_agent(&state.inner.db, id)
+        .await
+        .unwrap_or(0);
+
     match crate::db::agents::delete_agent(&state.inner.db, id).await {
         Ok(true) => {
             let _ = crate::db::audit::insert_audit_log(
@@ -209,7 +244,11 @@ async fn delete_agent_handler(
                 None,
                 "agents.delete",
                 Some("agent"),
-                Some(json!({ "agent_id": id, "request_id": context.request_id })),
+                Some(json!({
+                    "agent_id": id,
+                    "request_id": context.request_id,
+                    "revoked_tokens": revoked_tokens,
+                })),
                 context.client_ip.as_deref(),
                 context.user_agent.as_deref(),
             )
@@ -219,6 +258,61 @@ async fn delete_agent_handler(
         Ok(false) => (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": "Agent not found" })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+#[derive(Deserialize)]
+struct EventsQuery {
+    #[serde(default)]
+    limit: Option<i64>,
+    #[serde(default)]
+    offset: Option<i64>,
+}
+
+async fn list_agent_events(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Query(q): Query<EventsQuery>,
+) -> (StatusCode, Json<Value>) {
+    let agent = match crate::db::agents::get_agent(&state.inner.db, id).await {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Agent not found" })),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+    if !user.is_admin() && agent.owner_user_id != Some(user.user_id) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Access denied" })),
+        );
+    }
+
+    let limit = q.limit.unwrap_or(50).clamp(1, 200);
+    let offset = q.offset.unwrap_or(0).max(0);
+
+    match crate::db::orion::list_for_agent(&state.inner.db, id, limit, offset).await {
+        Ok(events) => (
+            StatusCode::OK,
+            Json(json!({
+                "events": events,
+                "limit": limit,
+                "offset": offset,
+            })),
         ),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/sao-server/src/routes/auth.rs
+++ b/crates/sao-server/src/routes/auth.rs
@@ -18,6 +18,14 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/auth/webauthn/register/start", post(register_start))
         .route("/api/auth/webauthn/register/finish", post(register_finish))
+        .route(
+            "/api/auth/webauthn/local/register/start",
+            post(local_register_start),
+        )
+        .route(
+            "/api/auth/webauthn/local/register/finish",
+            post(local_register_finish),
+        )
         .route("/api/auth/webauthn/login/start", post(login_start))
         .route("/api/auth/webauthn/login/finish", post(login_finish))
         .route("/api/auth/refresh", post(refresh_token))
@@ -28,6 +36,80 @@ pub fn routes() -> Router<AppState> {
 #[derive(Deserialize)]
 struct RegisterStartRequest {
     username: String,
+}
+
+#[derive(Deserialize)]
+struct LocalRegisterStartRequest {
+    username: Option<String>,
+}
+
+async fn local_register_start(
+    State(state): State<AppState>,
+    Json(req): Json<LocalRegisterStartRequest>,
+) -> impl IntoResponse {
+    if !local_bootstrap_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Local Windows Hello registration is disabled" })),
+        );
+    }
+
+    let local_username = local_bootstrap_username();
+    let username = req
+        .username
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&local_username);
+
+    if username != local_username {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!("Local Windows Hello registration is only available for {local_username}")
+            })),
+        );
+    }
+
+    let user = match crate::db::users::get_user_by_username(&state.inner.db, username).await {
+        Ok(Some(user)) if user.role == "admin" => user,
+        Ok(Some(_)) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(json!({ "error": "Local bootstrap user must be an admin" })),
+            );
+        }
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({
+                    "error": "Local bootstrap user not found. Run bootstrap-local first."
+                })),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    start_registration_for_user(state, user).await
+}
+
+async fn local_register_finish(
+    State(state): State<AppState>,
+    Json(req): Json<RegisterFinishRequest>,
+) -> impl IntoResponse {
+    if !local_bootstrap_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Local Windows Hello registration is disabled" })),
+        );
+    }
+
+    finish_registration_for_challenge(state, req).await
 }
 
 async fn register_start(
@@ -58,6 +140,26 @@ async fn register_start(
         }
     };
 
+    start_registration_for_user(state, user).await
+}
+
+#[derive(Deserialize)]
+struct RegisterFinishRequest {
+    challenge_id: String,
+    credential: RegisterPublicKeyCredential,
+}
+
+async fn register_finish(
+    State(state): State<AppState>,
+    Json(req): Json<RegisterFinishRequest>,
+) -> impl IntoResponse {
+    finish_registration_for_challenge(state, req).await
+}
+
+async fn start_registration_for_user(
+    state: AppState,
+    user: crate::db::users::UserRow,
+) -> (StatusCode, Json<serde_json::Value>) {
     let existing_creds =
         match crate::db::webauthn::get_credentials_for_user(&state.inner.db, user.id).await {
             Ok(creds) => creds
@@ -103,16 +205,10 @@ async fn register_start(
     }
 }
 
-#[derive(Deserialize)]
-struct RegisterFinishRequest {
-    challenge_id: String,
-    credential: RegisterPublicKeyCredential,
-}
-
-async fn register_finish(
-    State(state): State<AppState>,
-    Json(req): Json<RegisterFinishRequest>,
-) -> impl IntoResponse {
+async fn finish_registration_for_challenge(
+    state: AppState,
+    req: RegisterFinishRequest,
+) -> (StatusCode, Json<serde_json::Value>) {
     let Some((user_id, reg_state)) = state
         .inner
         .security
@@ -171,6 +267,26 @@ async fn register_finish(
             Json(json!({ "error": format!("Registration verification failed: {}", e) })),
         ),
     }
+}
+
+fn local_bootstrap_enabled() -> bool {
+    std::env::var("SAO_LOCAL_BOOTSTRAP")
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn local_bootstrap_username() -> String {
+    std::env::var("SAO_LOCAL_ADMIN_USERNAME")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "local-admin".to_string())
 }
 
 #[derive(Deserialize)]
@@ -370,13 +486,7 @@ async fn login_finish(
             )
             .await;
 
-            authenticated_response(
-                &state,
-                &user,
-                access_token,
-                refresh_token,
-                StatusCode::OK,
-            )
+            authenticated_response(&state, &user, access_token, refresh_token, StatusCode::OK)
         }
         Err(e) => (
             StatusCode::UNAUTHORIZED,
@@ -386,10 +496,7 @@ async fn login_finish(
     }
 }
 
-async fn refresh_token(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
+async fn refresh_token(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let Some(refresh_token) = cookie_value(&headers, session::REFRESH_COOKIE_NAME) else {
         let mut response = (
             StatusCode::UNAUTHORIZED,
@@ -482,12 +589,7 @@ async fn refresh_token(
         &new_refresh,
     );
 
-    (
-        StatusCode::OK,
-        headers,
-        Json(json!({ "refreshed": true })),
-    )
-        .into_response()
+    (StatusCode::OK, headers, Json(json!({ "refreshed": true }))).into_response()
 }
 
 async fn logout(

--- a/crates/sao-server/src/routes/bundle.rs
+++ b/crates/sao-server/src/routes/bundle.rs
@@ -1,0 +1,212 @@
+//! GET /api/agents/:id/bundle — packages a config.json + Tauri MSI installer for the user to
+//! run on their workstation. The config.json carries the entity's identity token and chosen
+//! LLM defaults. The MSI is read from `SAO_ORION_INSTALLER_PATH`.
+
+use std::io::{Cursor, Write};
+
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::{header, HeaderValue, StatusCode},
+    response::Response,
+    routing::get,
+    Router,
+};
+use axum::Json;
+use serde_json::{json, Value};
+use uuid::Uuid;
+use zip::write::SimpleFileOptions;
+use zip::CompressionMethod;
+
+use crate::auth::agent_tokens;
+use crate::auth::middleware::AuthUser;
+use crate::security::RequestAuditContext;
+use crate::state::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/api/agents/:id/bundle", get(download_bundle))
+}
+
+const README_TEXT: &str = "OrionII entity bundle\n\
+=====================\n\
+\n\
+This ZIP contains:\n\
+  config.json            -- Identity token + LLM provider defaults for this entity.\n\
+  OrionII-Setup.msi      -- Tauri installer (Windows).\n\
+  README-FIRST-RUN.txt   -- this file.\n\
+\n\
+First run\n\
+---------\n\
+1. Install: double-click OrionII-Setup.msi.\n\
+2. Drop config.json into:\n\
+       %APPDATA%\\OrionII\\config.json\n\
+   (the installer also accepts it co-located with OrionII.exe).\n\
+3. Launch OrionII. It will adopt the agent_id from config and phone home to SAO.\n\
+\n\
+Security\n\
+--------\n\
+The agent_token is a long-lived bearer credential. Treat config.json like an API key:\n\
+do not share, do not commit. If lost, delete the agent in SAO and download a new bundle.\n";
+
+async fn download_bundle(
+    user: AuthUser,
+    State(state): State<AppState>,
+    axum::extract::Extension(context): axum::extract::Extension<RequestAuditContext>,
+    Path(id): Path<Uuid>,
+) -> Result<Response, (StatusCode, Json<Value>)> {
+    let agent = crate::db::agents::get_agent(&state.inner.db, id)
+        .await
+        .map_err(|e| internal(e.to_string()))?
+        .ok_or_else(|| not_found("Agent not found"))?;
+
+    if !user.is_admin() && agent.owner_user_id != Some(user.user_id) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Access denied" })),
+        ));
+    }
+
+    let provider = agent
+        .default_provider
+        .as_deref()
+        .ok_or_else(|| bad_request("Agent has no default LLM provider configured"))?;
+    let id_model = agent
+        .default_id_model
+        .as_deref()
+        .ok_or_else(|| bad_request("Agent has no default Id model configured"))?;
+    let ego_model = agent
+        .default_ego_model
+        .as_deref()
+        .ok_or_else(|| bad_request("Agent has no default Ego model configured"))?;
+
+    let provider_settings = crate::db::llm_providers::get(&state.inner.db, provider)
+        .await
+        .map_err(|e| internal(e.to_string()))?
+        .ok_or_else(|| bad_request("Configured provider is not registered"))?;
+    if !provider_settings.enabled {
+        return Err(bad_request(
+            "Configured provider is currently disabled by an administrator",
+        ));
+    }
+
+    let installer_path = std::env::var("SAO_ORION_INSTALLER_PATH").map_err(|_| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "error": "OrionII installer is not staged on this SAO instance",
+                "hint": "Set SAO_ORION_INSTALLER_PATH to a built .msi (run npm run tauri build in OrionII)",
+            })),
+        )
+    })?;
+    let installer_bytes = tokio::fs::read(&installer_path).await.map_err(|e| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "error": format!("Failed to read installer at {installer_path}: {e}"),
+            })),
+        )
+    })?;
+
+    // Revoke any prior tokens for this agent before issuing a new one — one live bundle per agent.
+    let revoked = agent_tokens::revoke_for_agent(&state.inner.db, id)
+        .await
+        .map_err(|e| internal(e.to_string()))?;
+
+    let minted = agent_tokens::mint_entity_token(
+        &state.inner.db,
+        &state.inner.jwt_secret,
+        agent.id,
+        &agent.name,
+        user.user_id,
+    )
+    .await
+    .map_err(|e| internal(e.to_string()))?;
+
+    let sao_base_url = std::env::var("SAO_PUBLIC_BASE_URL")
+        .unwrap_or_else(|_| "http://localhost:3100".to_string());
+
+    let config = json!({
+        "sao_base_url": sao_base_url,
+        "agent_id": agent.id,
+        "agent_token": minted.jwt,
+        "default_provider": provider,
+        "default_id_model": id_model,
+        "default_ego_model": ego_model,
+        "client_version_min": "0.1.0",
+    });
+
+    let zip_bytes = build_zip(&config, &installer_bytes).map_err(|e| internal(e.to_string()))?;
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(user.user_id),
+        Some(agent.id),
+        "agents.bundle_downloaded",
+        Some("agent"),
+        Some(json!({
+            "agent_id": agent.id,
+            "token_jti": minted.jti,
+            "token_expires_at": minted.expires_at,
+            "revoked_prior_tokens": revoked,
+            "request_id": context.request_id,
+        })),
+        context.client_ip.as_deref(),
+        context.user_agent.as_deref(),
+    )
+    .await;
+
+    let short_id = agent.id.to_string()[..8].to_string();
+    let safe_name: String = agent
+        .name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let filename = format!("Orion-{}-{}.zip", safe_name, short_id);
+
+    let mut response = Response::new(Body::from(zip_bytes));
+    *response.status_mut() = StatusCode::OK;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/zip"),
+    );
+    response.headers_mut().insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
+            .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
+    );
+    Ok(response)
+}
+
+fn build_zip(config: &Value, installer: &[u8]) -> std::io::Result<Vec<u8>> {
+    let buffer = Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(buffer);
+    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    let config_bytes = serde_json::to_vec_pretty(config)?;
+    zip.start_file("config.json", opts)?;
+    zip.write_all(&config_bytes)?;
+
+    zip.start_file("OrionII-Setup.msi", opts)?;
+    zip.write_all(installer)?;
+
+    zip.start_file("README-FIRST-RUN.txt", opts)?;
+    zip.write_all(README_TEXT.as_bytes())?;
+
+    let cursor = zip.finish()?;
+    Ok(cursor.into_inner())
+}
+
+fn internal(msg: String) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "error": msg })),
+    )
+}
+
+fn bad_request(msg: &str) -> (StatusCode, Json<Value>) {
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": msg })))
+}
+
+fn not_found(msg: &str) -> (StatusCode, Json<Value>) {
+    (StatusCode::NOT_FOUND, Json(json!({ "error": msg })))
+}

--- a/crates/sao-server/src/routes/llm.rs
+++ b/crates/sao-server/src/routes/llm.rs
@@ -1,0 +1,144 @@
+//! POST /api/llm/generate — entity-token-authenticated proxy to a configured LLM provider.
+
+use axum::{
+    async_trait,
+    extract::{FromRequestParts, State},
+    http::{header::AUTHORIZATION, request::Parts, StatusCode},
+    routing::post,
+    Json, Router,
+};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::auth::agent_tokens;
+use crate::llm::{self, GenerateRequest};
+use crate::security::RequestAuditContext;
+use crate::state::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/api/llm/generate", post(generate_handler))
+}
+
+#[derive(Debug, Clone)]
+struct EntityCaller {
+    agent_id: Uuid,
+    human_owner: Uuid,
+}
+
+#[async_trait]
+impl FromRequestParts<AppState> for EntityCaller {
+    type Rejection = (StatusCode, Json<Value>);
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let token = parts
+            .headers
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({ "error": "Bearer entity token required" })),
+                )
+            })?;
+
+        let claims =
+            agent_tokens::validate_entity_token(&state.inner.db, &state.inner.jwt_secret, token)
+                .await
+                .map_err(|_| {
+                    (
+                        StatusCode::UNAUTHORIZED,
+                        Json(json!({ "error": "Invalid or revoked entity token" })),
+                    )
+                })?;
+
+        let agent_id = claims.agent_id().map_err(|_| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Invalid agent_id in token" })),
+            )
+        })?;
+        let human_owner = claims.human_owner_id().map_err(|_| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Invalid human_owner in token" })),
+            )
+        })?;
+
+        Ok(Self {
+            agent_id,
+            human_owner,
+        })
+    }
+}
+
+async fn generate_handler(
+    caller: EntityCaller,
+    State(state): State<AppState>,
+    axum::extract::Extension(context): axum::extract::Extension<RequestAuditContext>,
+    Json(req): Json<GenerateRequest>,
+) -> (StatusCode, Json<Value>) {
+    if req.prompt.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "prompt is required" })),
+        );
+    }
+
+    match llm::dispatch(&state, &req).await {
+        Ok(resp) => {
+            let _ = crate::db::audit::insert_audit_log(
+                &state.inner.db,
+                Some(caller.human_owner),
+                Some(caller.agent_id),
+                "llm.generate",
+                Some("llm"),
+                Some(json!({
+                    "provider": req.provider,
+                    "model": req.model,
+                    "role": req.role,
+                    "latency_ms": resp.latency_ms,
+                    "request_id": context.request_id,
+                })),
+                context.client_ip.as_deref(),
+                context.user_agent.as_deref(),
+            )
+            .await;
+            (StatusCode::OK, Json(json!(resp)))
+        }
+        Err(e) => {
+            let status = match &e {
+                llm::LlmError::ProviderDisabled(_)
+                | llm::LlmError::ProviderUnconfigured(_)
+                | llm::LlmError::ModelNotApproved { .. } => StatusCode::BAD_REQUEST,
+                llm::LlmError::VaultSealed => StatusCode::SERVICE_UNAVAILABLE,
+                llm::LlmError::ProviderError { .. }
+                | llm::LlmError::Http(_)
+                | llm::LlmError::BadResponse(_) => StatusCode::BAD_GATEWAY,
+                llm::LlmError::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            let _ = crate::db::audit::insert_audit_log(
+                &state.inner.db,
+                Some(caller.human_owner),
+                Some(caller.agent_id),
+                "llm.generate.failed",
+                Some("llm"),
+                Some(json!({
+                    "provider": req.provider,
+                    "model": req.model,
+                    "error": e.to_string(),
+                    "request_id": context.request_id,
+                })),
+                context.client_ip.as_deref(),
+                context.user_agent.as_deref(),
+            )
+            .await;
+            (status, Json(json!({ "error": e.to_string() })))
+        }
+    }
+}

--- a/crates/sao-server/src/routes/mod.rs
+++ b/crates/sao-server/src/routes/mod.rs
@@ -1,8 +1,11 @@
 pub mod admin;
 pub mod agents;
 pub mod auth;
+pub mod bundle;
 pub mod health;
+pub mod llm;
 pub mod oidc;
+pub mod orion;
 pub mod setup;
 pub mod skills;
 pub mod vault;
@@ -21,5 +24,8 @@ pub fn routes() -> Router<AppState> {
         .merge(agents::routes())
         .merge(vault::routes())
         .merge(admin::routes())
+        .merge(orion::routes())
         .merge(skills::routes())
+        .merge(llm::routes())
+        .merge(bundle::routes())
 }

--- a/crates/sao-server/src/routes/oidc.rs
+++ b/crates/sao-server/src/routes/oidc.rs
@@ -17,7 +17,7 @@ const ENV_PROVIDER_ID: &str = "entra";
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/auth/oidc/providers", get(list_providers))
-        .route("/api/auth/oidc/{provider_id}/authorize", get(authorize))
+        .route("/api/auth/oidc/:provider_id/authorize", get(authorize))
         .route("/api/auth/oidc/callback", get(callback))
 }
 
@@ -250,7 +250,9 @@ async fn resolve_provider(
         } else {
             return Err((
                 StatusCode::SERVICE_UNAVAILABLE,
-                Json(json!({ "error": "Vault must be unsealed to use database-backed OIDC providers" })),
+                Json(
+                    json!({ "error": "Vault must be unsealed to use database-backed OIDC providers" }),
+                ),
             ));
         }
     } else {
@@ -310,8 +312,8 @@ async fn load_or_create_user(
         if let Ok(provider_id) = uuid::Uuid::parse_str(&provider.key) {
             if let Some(uid) =
                 crate::db::oidc::find_user_by_oidc(&state.inner.db, provider_id, &user_info.subject)
-                .await
-                .map_err(|e| e.to_string())?
+                    .await
+                    .map_err(|e| e.to_string())?
             {
                 if bootstrap_admin {
                     crate::db::users::update_user_role(&state.inner.db, uid, "admin")

--- a/crates/sao-server/src/routes/orion.rs
+++ b/crates/sao-server/src/routes/orion.rs
@@ -1,0 +1,436 @@
+use axum::{
+    async_trait,
+    extract::{FromRequestParts, State},
+    http::{header::AUTHORIZATION, request::Parts, StatusCode},
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::auth::agent_tokens;
+use crate::auth::session;
+use crate::security::RequestAuditContext;
+use crate::state::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/orion/policy", get(get_policy))
+        .route("/api/orion/egress", post(post_egress))
+}
+
+/// Authenticated principal calling /api/orion/* — either a downloaded entity (preferred) or a
+/// human user (back-compat for the dev-token flow). For audit + persistence the call site uses
+/// `attribution_user()` to resolve a human owner regardless of which path matched.
+#[derive(Debug, Clone)]
+pub(crate) enum OrionBearerUser {
+    Entity {
+        agent_id: Uuid,
+        human_owner: Uuid,
+    },
+    User {
+        user_id: Uuid,
+    },
+}
+
+impl OrionBearerUser {
+    /// User_id to attribute writes to (human owner for entity tokens).
+    pub(crate) fn attribution_user(&self) -> Uuid {
+        match self {
+            OrionBearerUser::Entity { human_owner, .. } => *human_owner,
+            OrionBearerUser::User { user_id } => *user_id,
+        }
+    }
+
+    /// Agent_id, if the bearer is an entity token. None for human users.
+    pub(crate) fn entity_agent_id(&self) -> Option<Uuid> {
+        match self {
+            OrionBearerUser::Entity { agent_id, .. } => Some(*agent_id),
+            OrionBearerUser::User { .. } => None,
+        }
+    }
+}
+
+#[async_trait]
+impl FromRequestParts<AppState> for OrionBearerUser {
+    type Rejection = (StatusCode, Json<Value>);
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let token = parts
+            .headers
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({ "error": "Bearer token required" })),
+                )
+            })?;
+
+        if let Ok(claims) =
+            agent_tokens::validate_entity_token(&state.inner.db, &state.inner.jwt_secret, token)
+                .await
+        {
+            let agent_id = claims.agent_id().map_err(|_| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({ "error": "Invalid entity token subject" })),
+                )
+            })?;
+            let human_owner = claims.human_owner_id().map_err(|_| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({ "error": "Invalid entity token human_owner" })),
+                )
+            })?;
+            return Ok(OrionBearerUser::Entity {
+                agent_id,
+                human_owner,
+            });
+        }
+
+        let claims = session::validate_token(token, &state.inner.jwt_secret).map_err(|_| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Invalid or expired token" })),
+            )
+        })?;
+        let user_id = Uuid::parse_str(&claims.sub).map_err(|_| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Invalid token subject" })),
+            )
+        })?;
+
+        Ok(OrionBearerUser::User { user_id })
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrionPolicyResponse {
+    version: u64,
+    source: &'static str,
+    rules: Vec<&'static str>,
+    updated_at: DateTime<Utc>,
+}
+
+async fn get_policy(_user: OrionBearerUser) -> Json<OrionPolicyResponse> {
+    Json(OrionPolicyResponse {
+        version: 1,
+        source: "sao",
+        rules: vec![
+            "Only ship sanitized Orion egress events.",
+            "Preserve correlation IDs on audit events.",
+        ],
+        updated_at: Utc::now(),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrionEgressRequest {
+    #[serde(default)]
+    agent_id: Option<Uuid>,
+    orion_id: Uuid,
+    events: Vec<OrionEgressEvent>,
+    /// OrionII semver of the calling client; recorded on the audit log.
+    #[serde(default)]
+    client_version: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OrionEgressEvent {
+    id: Uuid,
+    enqueued_at: DateTime<Utc>,
+    attempts: u32,
+    event: OrionEvent,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum OrionEvent {
+    AuditAction {
+        action: String,
+        correlation_id: Uuid,
+    },
+    MemoryEvent {
+        memory_id: Uuid,
+        content: String,
+    },
+    IdentitySync {
+        orion_id: Uuid,
+        version: u64,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrionEgressResponse {
+    accepted: usize,
+    duplicate: usize,
+    failed: usize,
+    results: Vec<OrionEgressResult>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrionEgressResult {
+    id: Uuid,
+    status: OrionEgressStatus,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OrionEgressStatus {
+    Acked,
+    Duplicate,
+    Failed,
+}
+
+async fn post_egress(
+    user: OrionBearerUser,
+    State(state): State<AppState>,
+    axum::extract::Extension(context): axum::extract::Extension<RequestAuditContext>,
+    Json(req): Json<OrionEgressRequest>,
+) -> (StatusCode, Json<Value>) {
+    if req.events.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "At least one event is required" })),
+        );
+    }
+
+    let attribution_user_id = user.attribution_user();
+    // Entity tokens carry their own agent_id; trust that over a body-supplied one.
+    let agent_id = user.entity_agent_id().or(req.agent_id);
+
+    let mut accepted = 0;
+    let mut duplicate = 0;
+    let mut failed = 0;
+    let mut results = Vec::with_capacity(req.events.len());
+
+    for event in &req.events {
+        match crate::db::orion::insert_egress_event_if_new(
+            &state.inner.db,
+            event.id,
+            attribution_user_id,
+            agent_id,
+            req.orion_id,
+            event.event.event_type(),
+            serde_json::to_value(event).unwrap_or_else(|_| json!({})),
+            event.enqueued_at,
+            event.attempts,
+        )
+        .await
+        {
+            Ok(true) => {
+                accepted += 1;
+                results.push(OrionEgressResult {
+                    id: event.id,
+                    status: OrionEgressStatus::Acked,
+                });
+            }
+            Ok(false) => {
+                duplicate += 1;
+                results.push(OrionEgressResult {
+                    id: event.id,
+                    status: OrionEgressStatus::Duplicate,
+                });
+            }
+            Err(error) => {
+                failed += 1;
+                tracing::warn!(
+                    event_id = %event.id,
+                    error = %error,
+                    "Failed to persist Orion egress event"
+                );
+                results.push(OrionEgressResult {
+                    id: event.id,
+                    status: OrionEgressStatus::Failed,
+                });
+            }
+        }
+    }
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(attribution_user_id),
+        agent_id,
+        "orion.egress",
+        Some("orion"),
+        Some(json!({
+            "orion_id": req.orion_id,
+            "client_version": req.client_version,
+            "accepted": accepted,
+            "duplicate": duplicate,
+            "failed": failed,
+            "event_count": req.events.len(),
+            "event_ids": req.events.iter().map(|event| event.id).collect::<Vec<_>>(),
+            "request_id": context.request_id,
+        })),
+        context.client_ip.as_deref(),
+        context.user_agent.as_deref(),
+    )
+    .await;
+
+    (
+        StatusCode::OK,
+        Json(json!(OrionEgressResponse {
+            accepted,
+            duplicate,
+            failed,
+            results,
+        })),
+    )
+}
+
+impl OrionEvent {
+    fn event_type(&self) -> &'static str {
+        match self {
+            OrionEvent::AuditAction { .. } => "auditAction",
+            OrionEvent::MemoryEvent { .. } => "memoryEvent",
+            OrionEvent::IdentitySync { .. } => "identitySync",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::webauthn::create_webauthn_from_config;
+    use crate::state::init_app_state_with_data_root;
+    use crate::vault_state::VaultState;
+    use axum::extract::FromRequestParts;
+
+    #[test]
+    fn egress_event_serializes_with_orion_contract_shape() {
+        let event = OrionEgressEvent {
+            id: Uuid::nil(),
+            enqueued_at: DateTime::parse_from_rfc3339("2026-04-25T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            attempts: 1,
+            event: OrionEvent::AuditAction {
+                action: "open local document".to_string(),
+                correlation_id: Uuid::nil(),
+            },
+        };
+
+        let serialized = serde_json::to_value(event).unwrap();
+
+        assert_eq!(serialized["id"], Uuid::nil().to_string());
+        assert!(serialized["event"].get("auditAction").is_some());
+        assert!(serialized["event"]["auditAction"]
+            .get("correlationId")
+            .is_some());
+    }
+
+    #[test]
+    fn egress_status_serializes_for_client_ack_logic() {
+        let result = OrionEgressResult {
+            id: Uuid::nil(),
+            status: OrionEgressStatus::Duplicate,
+        };
+
+        let serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(serialized["status"], "duplicate");
+    }
+
+    #[tokio::test]
+    async fn bearer_extractor_rejects_missing_authorization_header() {
+        let state = test_state();
+        let (mut parts, _) = axum::http::Request::builder()
+            .body(())
+            .unwrap()
+            .into_parts();
+
+        let rejection = OrionBearerUser::from_request_parts(&mut parts, &state)
+            .await
+            .expect_err("missing bearer token should be rejected");
+
+        assert_eq!(rejection.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn bearer_extractor_accepts_valid_bearer_token() {
+        let state = test_state();
+        let user_id = Uuid::new_v4();
+        let token = session::create_access_token(user_id, "orion-dev", "user", &[7u8; 32]).unwrap();
+        let (mut parts, _) = axum::http::Request::builder()
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .body(())
+            .unwrap()
+            .into_parts();
+
+        let user = OrionBearerUser::from_request_parts(&mut parts, &state)
+            .await
+            .expect("valid bearer token should authenticate");
+
+        match user {
+            OrionBearerUser::User { user_id: extracted } => assert_eq!(extracted, user_id),
+            OrionBearerUser::Entity { .. } => {
+                panic!("user JWT should not be classified as entity token")
+            }
+        }
+    }
+
+    #[test]
+    fn egress_status_serializes_failed_for_retry_logic() {
+        let result = OrionEgressResult {
+            id: Uuid::nil(),
+            status: OrionEgressStatus::Failed,
+        };
+
+        let serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(serialized["status"], "failed");
+    }
+
+    #[test]
+    fn event_type_names_match_contract_variants() {
+        assert_eq!(
+            OrionEvent::IdentitySync {
+                orion_id: Uuid::nil(),
+                version: 1,
+            }
+            .event_type(),
+            "identitySync"
+        );
+        assert_eq!(
+            OrionEvent::MemoryEvent {
+                memory_id: Uuid::nil(),
+                content: "memory".to_string(),
+            }
+            .event_type(),
+            "memoryEvent"
+        );
+    }
+
+    fn test_state() -> AppState {
+        let data_root = std::env::temp_dir().join(format!("sao-orion-test-{}", Uuid::new_v4()));
+        let pool = sqlx::PgPool::connect_lazy("postgresql://tester:secret@127.0.0.1:1/sao_test")
+            .expect("lazy pool should be created");
+        let webauthn = create_webauthn_from_config("localhost", "http://localhost:3100")
+            .expect("local WebAuthn config should be valid");
+
+        init_app_state_with_data_root(
+            pool,
+            VaultState::Uninitialized,
+            webauthn,
+            [7u8; 32],
+            data_root,
+        )
+        .expect("test app state should initialize")
+    }
+}

--- a/crates/sao-server/src/routes/setup.rs
+++ b/crates/sao-server/src/routes/setup.rs
@@ -8,8 +8,24 @@ pub fn routes() -> Router<AppState> {
 }
 
 async fn setup_status(State(state): State<AppState>) -> Json<Value> {
-    let vault_state = state.inner.vault_state.read().await;
-    let initialized = !matches!(*vault_state, crate::vault_state::VaultState::Uninitialized);
+    let initialized = {
+        let vault_state = state.inner.vault_state.read().await;
+        !matches!(*vault_state, crate::vault_state::VaultState::Uninitialized)
+    };
+    let initialized = if initialized {
+        true
+    } else {
+        match crate::db::vault_key::vmk_exists(&state.inner.db).await {
+            Ok(true) => {
+                let mut vault_state = state.inner.vault_state.write().await;
+                if matches!(*vault_state, crate::vault_state::VaultState::Uninitialized) {
+                    *vault_state = crate::vault_state::VaultState::Sealed;
+                }
+                true
+            }
+            _ => false,
+        }
+    };
     let has_users = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM users")
         .fetch_one(&state.inner.db)
         .await
@@ -23,7 +39,12 @@ async fn setup_status(State(state): State<AppState>) -> Json<Value> {
         "needs_setup": needs_setup,
         "bootstrap_mode": if needs_setup { "installer_required" } else { "operational" },
         "recommended_installer": {
-            "command": "docker build -f installer/Dockerfile -t sao-installer installer && docker run --rm -it -e ANTHROPIC_API_KEY=<your-key> sao-installer",
+            "command": "docker build -f installer/Dockerfile -t sao-installer installer\ndocker run --rm -it -e ANTHROPIC_API_KEY=<your-key> sao-installer",
+            "commands": {
+                "powershell": "cd C:\\Repo\\SAO\ndocker build -f installer/Dockerfile -t sao-installer installer\ndocker run --rm -it -e ANTHROPIC_API_KEY=\"<your-key>\" sao-installer",
+                "bash": "cd /path/to/SAO\ndocker build -f installer/Dockerfile -t sao-installer installer && docker run --rm -it -e ANTHROPIC_API_KEY=<your-key> sao-installer",
+                "published_image": "docker run --rm -it -e ANTHROPIC_API_KEY=<your-key> ghcr.io/jbcupps/sao-installer:latest"
+            },
             "image_role": "standalone_conversational_bootstrapper",
         },
     }))

--- a/crates/sao-server/src/routes/skills.rs
+++ b/crates/sao-server/src/routes/skills.rs
@@ -15,29 +15,29 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         // Authenticated user routes
         .route("/api/skills", get(list_skills))
-        .route("/api/skills/{id}", get(get_skill))
-        .route("/api/skills/{id}/reviews", get(list_skill_reviews))
+        .route("/api/skills/:id", get(get_skill))
+        .route("/api/skills/:id/reviews", get(list_skill_reviews))
         .route(
-            "/api/skills/bindings/{id}/reviews",
+            "/api/skills/bindings/:id/reviews",
             get(list_binding_reviews),
         )
-        .route("/api/agents/{agent_id}/skills", get(list_agent_skills))
+        .route("/api/agents/:agent_id/skills", get(list_agent_skills))
         .route(
-            "/api/agents/{agent_id}/skills/checkin",
+            "/api/agents/:agent_id/skills/checkin",
             post(agent_skill_checkin),
         )
         // Admin routes
         .route("/api/admin/skills", post(admin_create_skill))
-        .route("/api/admin/skills/{id}", put(admin_update_skill))
-        .route("/api/admin/skills/{id}", delete(admin_delete_skill))
-        .route("/api/admin/skills/{id}/review", post(admin_review_skill))
+        .route("/api/admin/skills/:id", put(admin_update_skill))
+        .route("/api/admin/skills/:id", delete(admin_delete_skill))
+        .route("/api/admin/skills/:id/review", post(admin_review_skill))
         .route("/api/admin/skills/pending", get(admin_list_pending_skills))
         .route(
             "/api/admin/skills/bindings/pending",
             get(admin_list_pending_bindings),
         )
         .route(
-            "/api/admin/skills/bindings/{id}/review",
+            "/api/admin/skills/bindings/:id/review",
             post(admin_review_binding),
         )
 }
@@ -235,9 +235,7 @@ async fn agent_skill_checkin(
                     action: review_action.to_string(),
                     reviewer_user_id: None,
                     policy_score: Some(policy.score as i32),
-                    policy_details: Some(
-                        serde_json::to_value(&policy.checks).unwrap_or(json!([])),
-                    ),
+                    policy_details: Some(serde_json::to_value(&policy.checks).unwrap_or(json!([]))),
                     notes: None,
                 },
             )
@@ -443,9 +441,7 @@ async fn admin_create_skill(
                     action: "manual_approve".to_string(),
                     reviewer_user_id: Some(admin.user_id),
                     policy_score: Some(policy.score as i32),
-                    policy_details: Some(
-                        serde_json::to_value(&policy.checks).unwrap_or(json!([])),
-                    ),
+                    policy_details: Some(serde_json::to_value(&policy.checks).unwrap_or(json!([]))),
                     notes: Some("Admin-created skill, auto-approved".to_string()),
                 },
             )

--- a/crates/sao-server/src/routes/vault.rs
+++ b/crates/sao-server/src/routes/vault.rs
@@ -18,9 +18,9 @@ pub fn routes() -> Router<AppState> {
         .route("/api/vault/seal", post(seal_vault))
         .route("/api/vault/secrets", get(list_secrets))
         .route("/api/vault/secrets", post(create_secret))
-        .route("/api/vault/secrets/{id}", get(get_secret))
-        .route("/api/vault/secrets/{id}", put(update_secret))
-        .route("/api/vault/secrets/{id}", delete(delete_secret))
+        .route("/api/vault/secrets/:id", get(get_secret))
+        .route("/api/vault/secrets/:id", put(update_secret))
+        .route("/api/vault/secrets/:id", delete(delete_secret))
 }
 
 async fn vault_status(State(state): State<AppState>) -> Json<Value> {

--- a/crates/sao-server/src/security.rs
+++ b/crates/sao-server/src/security.rs
@@ -81,7 +81,11 @@ impl SecurityState {
         let secure = std::env::var("SAO_COOKIE_SECURE")
             .ok()
             .and_then(|value| parse_bool(&value))
-            .unwrap_or_else(|| allowed_origins.iter().any(|origin| origin.starts_with("https://")));
+            .unwrap_or_else(|| {
+                allowed_origins
+                    .iter()
+                    .any(|origin| origin.starts_with("https://"))
+            });
         let domain = std::env::var("SAO_COOKIE_DOMAIN")
             .ok()
             .map(|value| value.trim().to_string())
@@ -177,12 +181,7 @@ impl ChallengeStore {
         }
     }
 
-    pub async fn insert_oidc_state(
-        &self,
-        state_id: String,
-        provider_key: String,
-        nonce: String,
-    ) {
+    pub async fn insert_oidc_state(&self, state_id: String, provider_key: String, nonce: String) {
         self.cleanup_expired().await;
         self.entries.lock().await.insert(
             state_id,
@@ -310,7 +309,10 @@ pub async fn enforce_request_security(
         }
     }
 
-    if path.starts_with("/api/") && requires_csrf(&method) {
+    if path.starts_with("/api/")
+        && requires_csrf(&method)
+        && !is_orion_machine_request(&path, request.headers())
+    {
         if let Some(origin) = context.origin.as_deref() {
             if !state.inner.security.is_allowed_origin(origin) {
                 tracing::warn!(
@@ -423,7 +425,8 @@ pub fn build_cookie(
 }
 
 pub fn build_expired_cookie(name: &str, config: &CookieConfig) -> String {
-    let mut cookie = format!("{name}=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax");
+    let mut cookie =
+        format!("{name}=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax");
     if config.secure {
         cookie.push_str("; Secure");
     }
@@ -479,15 +482,21 @@ fn build_request_context(headers: &HeaderMap) -> RequestAuditContext {
 
 fn set_request_id_header(headers: &mut HeaderMap, request_id: &str) {
     if let Ok(value) = HeaderValue::from_str(request_id) {
-        headers.insert(
-            HeaderName::from_static(REQUEST_ID_HEADER),
-            value,
-        );
+        headers.insert(HeaderName::from_static(REQUEST_ID_HEADER), value);
     }
 }
 
 fn requires_csrf(method: &Method) -> bool {
     !matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
+}
+
+fn is_orion_machine_request(path: &str, headers: &HeaderMap) -> bool {
+    let has_bearer = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .is_some_and(|value| value.starts_with("Bearer "));
+    has_bearer && (path == "/api/orion/egress" || path.starts_with("/api/orion/"))
 }
 
 fn rate_limit_bucket(method: &Method, path: &str) -> Option<(&'static str, usize, Duration)> {
@@ -496,17 +505,13 @@ fn rate_limit_bucket(method: &Method, path: &str) -> Option<(&'static str, usize
         | ("POST", "/api/auth/webauthn/register/finish")
         | ("POST", "/api/auth/webauthn/login/start")
         | ("POST", "/api/auth/webauthn/login/finish")
-        | ("GET", "/api/auth/oidc/callback") => {
-            Some(("auth", 20, Duration::from_secs(60)))
-        }
+        | ("GET", "/api/auth/oidc/callback") => Some(("auth", 20, Duration::from_secs(60))),
         ("GET", path) if path.starts_with("/api/auth/oidc/") => {
             Some(("oidc", 20, Duration::from_secs(60)))
         }
         ("POST", "/api/auth/refresh") => Some(("refresh", 30, Duration::from_secs(60))),
         ("POST", "/api/vault/unseal") => Some(("vault-unseal", 5, Duration::from_secs(300))),
-        ("POST", "/api/admin/oidc/providers") => {
-            Some(("admin-oidc", 30, Duration::from_secs(60)))
-        }
+        ("POST", "/api/admin/oidc/providers") => Some(("admin-oidc", 30, Duration::from_secs(60))),
         ("PUT", path) if path.starts_with("/api/admin/oidc/providers/") => {
             Some(("admin-oidc", 30, Duration::from_secs(60)))
         }
@@ -514,6 +519,7 @@ fn rate_limit_bucket(method: &Method, path: &str) -> Option<(&'static str, usize
             Some(("admin-oidc", 30, Duration::from_secs(60)))
         }
         ("POST", "/api/agents") => Some(("agents-create", 20, Duration::from_secs(60))),
+        ("POST", "/api/orion/egress") => Some(("orion-egress", 120, Duration::from_secs(60))),
         ("POST", path) if path.starts_with("/api/agents/") && path.ends_with("/skills/checkin") => {
             Some(("skill-checkin", 30, Duration::from_secs(60)))
         }
@@ -561,6 +567,24 @@ mod tests {
         assert_eq!(parse_bool("true"), Some(true));
         assert_eq!(parse_bool("OFF"), Some(false));
         assert_eq!(parse_bool("maybe"), None);
+    }
+
+    #[test]
+    fn orion_machine_paths_are_csrf_scoped() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer token"),
+        );
+        assert!(super::is_orion_machine_request(
+            "/api/orion/egress",
+            &headers
+        ));
+        assert!(!super::is_orion_machine_request("/api/agents", &headers));
+        assert!(!super::is_orion_machine_request(
+            "/api/orion/egress",
+            &HeaderMap::new()
+        ));
     }
 
     #[tokio::test]

--- a/crates/sao-server/src/state.rs
+++ b/crates/sao-server/src/state.rs
@@ -53,7 +53,7 @@ pub fn init_app_state(
     init_app_state_with_data_root(db, vault_state, webauthn, jwt_secret, data_root)
 }
 
-fn init_app_state_with_data_root(
+pub(crate) fn init_app_state_with_data_root(
     db: PgPool,
     vault_state: VaultState,
     webauthn: Webauthn,

--- a/crates/sao-server/tests/route_contracts.rs
+++ b/crates/sao-server/tests/route_contracts.rs
@@ -16,14 +16,14 @@ fn vault_routes_use_vault_secrets_namespace() {
     assert!(src.contains("/api/vault/unseal"));
     assert!(src.contains("/api/vault/seal"));
     assert!(src.contains("/api/vault/secrets"));
-    assert!(src.contains("/api/vault/secrets/{id}"));
+    assert!(src.contains("/api/vault/secrets/:id"));
 }
 
 #[test]
 fn oidc_routes_use_authorize_endpoint() {
     let src = include_str!("../src/routes/oidc.rs");
     assert!(src.contains("/api/auth/oidc/providers"));
-    assert!(src.contains("/api/auth/oidc/{provider_id}/authorize"));
+    assert!(src.contains("/api/auth/oidc/:provider_id/authorize"));
     assert!(src.contains("/api/auth/oidc/callback"));
 }
 
@@ -31,14 +31,53 @@ fn oidc_routes_use_authorize_endpoint() {
 fn admin_routes_use_oidc_provider_namespace() {
     let src = include_str!("../src/routes/admin.rs");
     assert!(src.contains("/api/admin/oidc/providers"));
-    assert!(src.contains("/api/admin/oidc/providers/{id}"));
+    assert!(src.contains("/api/admin/oidc/providers/:id"));
 }
 
 #[test]
-fn routes_use_brace_path_params_for_agents_without_public_ws_route() {
+fn agents_routes_use_axum07_path_params_with_dual_method_delete() {
     let agents_src = include_str!("../src/routes/agents.rs");
-    assert!(agents_src.contains("/api/agents/{id}"));
-    assert!(!agents_src.contains("/api/agents/:id"));
+    assert!(agents_src.contains("/api/agents/:id"));
+    assert!(agents_src.contains("/api/agents/:id/delete"));
+    assert!(agents_src.contains(".post(delete_agent_handler)"));
+    assert!(agents_src.contains(".delete(delete_agent_handler)"));
+    assert!(
+        !agents_src.contains("/api/agents/{id}"),
+        "axum 0.7 with matchit 0.7 does not parse `{{id}}`; use `:id` instead",
+    );
+}
+
+#[test]
+fn no_route_uses_brace_path_param_syntax_anywhere() {
+    let route_files = [
+        ("agents.rs", include_str!("../src/routes/agents.rs")),
+        ("admin.rs", include_str!("../src/routes/admin.rs")),
+        ("auth.rs", include_str!("../src/routes/auth.rs")),
+        ("health.rs", include_str!("../src/routes/health.rs")),
+        ("oidc.rs", include_str!("../src/routes/oidc.rs")),
+        ("orion.rs", include_str!("../src/routes/orion.rs")),
+        ("setup.rs", include_str!("../src/routes/setup.rs")),
+        ("skills.rs", include_str!("../src/routes/skills.rs")),
+        ("vault.rs", include_str!("../src/routes/vault.rs")),
+    ];
+    for (name, src) in route_files {
+        for line in src.lines() {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with(".route(") {
+                continue;
+            }
+            if let Some(start) = trimmed.find('"') {
+                let rest = &trimmed[start + 1..];
+                if let Some(end) = rest.find('"') {
+                    let path = &rest[..end];
+                    assert!(
+                        !(path.contains('{') && path.contains('}')),
+                        "{name}: route `{path}` uses brace-style placeholders; axum 0.7 with matchit 0.7 needs `:param` syntax",
+                    );
+                }
+            }
+        }
+    }
 }
 
 #[test]
@@ -46,4 +85,22 @@ fn setup_routes_do_not_expose_legacy_initialize_endpoint() {
     let src = include_str!("../src/routes/setup.rs");
     assert!(src.contains("/api/setup/status"));
     assert!(!src.contains("/api/setup/initialize"));
+}
+
+#[test]
+fn orion_routes_define_machine_policy_and_egress_contract() {
+    let src = include_str!("../src/routes/orion.rs");
+    assert!(src.contains("/api/orion/policy"));
+    assert!(src.contains("/api/orion/egress"));
+    assert!(src.contains("OrionBearerUser"));
+    assert!(src.contains("OrionEgressRequest"));
+}
+
+#[test]
+fn security_keeps_orion_csrf_exception_scoped() {
+    let src = include_str!("../src/security.rs");
+    assert!(src.contains("is_orion_machine_request"));
+    assert!(src.contains("\"/api/orion/egress\""));
+    assert!(src.contains("requires_csrf(&method)"));
+    assert!(src.contains("Bearer "));
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       SAO_DATA_DIR: /data/sao
       SAO_STATIC_DIR: /srv/sao/static
       RUST_LOG: ${RUST_LOG:-info}
+      SAO_JWT_SECRET: ${SAO_JWT_SECRET:-}
+      SAO_LOCAL_BOOTSTRAP: ${SAO_LOCAL_BOOTSTRAP:-false}
+      SAO_LOCAL_ADMIN_USERNAME: ${SAO_LOCAL_ADMIN_USERNAME:-local-admin}
       DATABASE_URL: postgres://${POSTGRES_USER:-sao}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your environment or .env}@db:5432/${POSTGRES_DB:-sao}
       SAO_RP_ID: ${SAO_RP_ID:-localhost}
       SAO_RP_ORIGIN: ${SAO_RP_ORIGIN:-http://localhost:3100}
@@ -22,8 +25,16 @@ services:
       SAO_OIDC_CLIENT_SECRET: ${SAO_OIDC_CLIENT_SECRET:-}
       SAO_OIDC_PROVIDER_NAME: ${SAO_OIDC_PROVIDER_NAME:-Microsoft Entra ID}
       SAO_OIDC_SCOPES: ${SAO_OIDC_SCOPES:-openid profile email}
+      # Used by /api/agents/:id/bundle to embed the right SAO URL in the entity config.json.
+      SAO_PUBLIC_BASE_URL: ${SAO_PUBLIC_BASE_URL:-http://localhost:3100}
+      # Path *inside the container* to the OrionII installer; only meaningful when the
+      # installer directory is mounted via SAO_ORION_INSTALLER_DIR (see volumes below).
+      SAO_ORION_INSTALLER_PATH: ${SAO_ORION_INSTALLER_PATH:-/installer/${SAO_ORION_INSTALLER_FILENAME:-OrionII_0.1.0_x64_en-US.msi}}
     volumes:
       - sao-data:/data/sao
+      # Mount the host directory containing the OrionII MSI so the bundle endpoint can read it.
+      # Set SAO_ORION_INSTALLER_DIR to the absolute host path (e.g., the bundle/msi output dir).
+      - ${SAO_ORION_INSTALLER_DIR:-./empty-installer-mount}:/installer:ro
     depends_on:
       db:
         condition: service_healthy

--- a/docs/bootstrap-installer.md
+++ b/docs/bootstrap-installer.md
@@ -4,10 +4,26 @@ The fastest path to a live SAO environment is the standalone installer container
 
 ## One Command
 
+Bash:
+
 ```bash
 docker run --rm -it \
   -e ANTHROPIC_API_KEY=sk-ant-your-key-here \
   ghcr.io/jbcupps/sao-installer:latest
+```
+
+Windows PowerShell:
+
+```powershell
+docker run --rm -it -e ANTHROPIC_API_KEY="sk-ant-your-key-here" ghcr.io/jbcupps/sao-installer:latest
+```
+
+Build the local installer image first when testing repository changes:
+
+```powershell
+cd C:\Repo\SAO
+docker build -f installer/Dockerfile -t sao-installer installer
+docker run --rm -it -e ANTHROPIC_API_KEY="sk-ant-your-key-here" sao-installer
 ```
 
 ## What The Installer Does

--- a/docs/orion-sao-mvp.md
+++ b/docs/orion-sao-mvp.md
@@ -1,0 +1,203 @@
+# OrionII + SAO MVP Contract
+
+This document is the shared local MVP contract for wiring `C:\Repo\OrionII` to `C:\Repo\SAO`.
+SAO owns the control plane: identity, secrets, agent lifecycle, LLM key custody, and audit. OrionII
+owns the durable local desktop runtime: identity continuity, document indexing, and egress to SAO.
+
+## MVP Scope
+
+- A signed-in SAO admin configures LLM provider keys (OpenAI / Anthropic / Ollama) once.
+- A signed-in SAO user creates an OrionII entity with a chosen provider + model.
+- The user downloads a bundle (`config.json` + `OrionII-Setup.msi`) from SAO.
+- The downloaded entity adopts the SAO-assigned identity, phones home for policy, ships egress
+  events, and routes all model calls through SAO's LLM proxy.
+- Browser setup remains installer-led; production bootstrap is the Azure conversational installer.
+- Local Docker MVP uses `sao-server bootstrap-local`.
+
+## Endpoints
+
+All endpoints are under the SAO API root.
+
+### `GET /api/orion/policy` *(entity bearer or user JWT)*
+
+Returns the current policy overlay for OrionII.
+
+```json
+{
+  "version": 1,
+  "source": "sao",
+  "rules": [
+    "Only ship sanitized Orion egress events.",
+    "Preserve correlation IDs on audit events."
+  ],
+  "updatedAt": "2026-04-25T00:00:00Z"
+}
+```
+
+### `POST /api/orion/egress` *(entity bearer or user JWT)*
+
+Accepts a batch of pending OrionII events. SAO trusts the entity bearer's `agent_id` claim over
+any `agentId` in the body.
+
+```json
+{
+  "agentId": "optional-sao-agent-id",
+  "orionId": "00000000-0000-0000-0000-000000000000",
+  "clientVersion": "0.1.0",
+  "events": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "enqueuedAt": "2026-04-25T00:00:00Z",
+      "attempts": 1,
+      "event": {
+        "auditAction": {
+          "action": "open local document",
+          "correlationId": "00000000-0000-0000-0000-000000000002"
+        }
+      }
+    }
+  ]
+}
+```
+
+Returns per-event status. Duplicate event ids ack idempotently.
+
+```json
+{
+  "accepted": 1,
+  "duplicate": 0,
+  "failed": 0,
+  "results": [
+    { "id": "00000000-0000-0000-0000-000000000001", "status": "acked" }
+  ]
+}
+```
+
+### `POST /api/llm/generate` *(entity bearer ONLY)*
+
+OrionII calls this for every Id/Ego prompt — **regardless of which provider the entity was
+created against**. There is no direct entity → provider call path; SAO is always in the middle so
+keys never leave the server, every call is auditable, and revoking an entity token immediately
+cuts off model access. SAO holds the provider keys and forwards to the configured upstream
+(OpenAI / Anthropic / Grok / Gemini / Ollama).
+
+Request:
+```json
+{
+  "provider": "ollama",
+  "model": "llama3.2",
+  "system": "You are Orion's Ego layer...",
+  "prompt": "User query: ...",
+  "temperature": 0.2,
+  "role": "ego"
+}
+```
+
+Response:
+```json
+{
+  "text": "...",
+  "model": "llama3.2",
+  "latencyMs": 873
+}
+```
+
+Errors:
+| Status | Cause |
+|---|---|
+| 400 | Provider not enabled / not registered / model not on the approved list. |
+| 401 | Bearer is not a valid (non-revoked) entity JWT. |
+| 502 | Provider call failed (network, bad response, upstream error). |
+| 503 | Vault is sealed. |
+
+### `GET /api/agents/:id/bundle` *(user session, owner or admin)*
+
+Mints a fresh entity JWT, revokes prior tokens for the same agent, packages a ZIP:
+
+```
+config.json            -- sao_base_url, agent_id, agent_token (JWT), default models, client_version_min
+OrionII-Setup.msi      -- Tauri installer (read from SAO_ORION_INSTALLER_PATH inside the container)
+README-FIRST-RUN.txt   -- install steps
+```
+
+Returns 503 if the installer is not staged with a clear remediation message.
+
+### `GET /api/agents/:id/events` *(user session, owner or admin)*
+
+Lists `orion_egress_events` rows for the agent. Pagination via `?limit=&offset=`. Backs the
+`/agents/:id/events` page in the SAO UI.
+
+### Admin LLM provider management
+
+Supported providers: `openai`, `anthropic`, `grok` (xAI), `gemini` (Google), `ollama` (local).
+The first four are key-bearing (API key stored in vault); Ollama is base-URL-only.
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/api/admin/llm-providers` | Returns provider settings + `has_api_key` (no secret material). |
+| PUT | `/api/admin/llm-providers/:provider` | Upserts settings; if `api_key` is in the body, replaces the encrypted vault entry at `(provider=<name>, label='api_key', secret_type='api_key')`. Vault must be unsealed. Validates that `ollama` does not receive an `api_key` and key-bearing providers do not receive a meaningless `base_url`. |
+| POST | `/api/admin/llm-providers/ollama/probe` | Body `{ "base_url": "..." }`. Calls `GET /api/tags`, returns the live model list. |
+| POST | `/api/admin/llm-providers/:provider/test` | Body `{ "model": "..." }` (defaults to `default_model`). Sends a tiny ping prompt through the real provider call path (key vault → upstream API). Returns `{ ok, model, latency_ms, preview, error? }`. Bypasses the approved-models gate so admins can probe new models before adding them to the allowlist. |
+
+### Per-provider key formats
+
+| Provider | Key shape | Console |
+|---|---|---|
+| `openai` | `sk-...` | https://platform.openai.com/api-keys |
+| `anthropic` | `sk-ant-...` | https://console.anthropic.com/settings/keys |
+| `grok` | `xai-...` | https://console.x.ai/ |
+| `gemini` | `AIza...` | https://aistudio.google.com/apikey |
+| `ollama` | (no key — base URL only) | n/a |
+
+## Authentication
+
+Three identities, three token shapes:
+
+1. **Browser users** — Cookie-based session, CSRF-protected. Used at `/admin/*`, `/agents`, `/vault`.
+2. **Local dev bearer** — User JWT minted by `sao-server mint-dev-token`. Sent as
+   `Authorization: Bearer <token>` for the legacy OrionII env-driven path.
+3. **Entity JWT** — Long-lived, OIDC-shaped, minted at bundle download. Each token is a JWT with:
+
+   ```json
+   {
+     "iss": "sao",
+     "aud": "sao-api",
+     "sub": "<agent_id>",
+     "jti": "<agent_tokens.id>",
+     "iat": ..., "nbf": ..., "exp": ...,
+     "principalType": "non_human",
+     "entityKind": "orion",
+     "entityName": "abigail",
+     "humanOwner": "<user_id>",
+     "scope": "orion:policy orion:egress llm:generate"
+   }
+   ```
+
+   Validation: HS256 signature against `SAO_JWT_SECRET`, plus a row check on `agent_tokens.id =
+   jti` (rejects revoked / unknown / expired). The shape is intentionally compatible with future
+   issuance from Entra or another external IdP — only the issuer/verifier swap, not the on-the-
+   wire contract.
+
+   Revocation: deleting an agent bulk-revokes all of its tokens. Re-downloading a bundle revokes
+   any prior tokens for that agent (one live bundle per agent).
+
+## CSRF Boundary
+
+`/api/orion/*` and `/api/llm/generate` are machine-client route groups. They accept Bearer auth
+and bypass browser CSRF. The general browser API keeps CSRF and origin enforcement intact.
+
+## Idempotency
+
+`SaoEgressRecord.id` is the idempotency key. SAO stores accepted ids in `orion_egress_events`.
+Duplicate ids ack as `duplicate` rather than `failed`. OrionII only marks records acked when SAO
+returns `acked` or `duplicate`.
+
+## Acceptance Criteria
+
+- Admin can configure an Ollama base URL + approved models via `/admin/llm-providers`.
+- A user can create an agent with a default provider + Id/Ego model.
+- Bundle download produces a ZIP whose `config.json` decodes a JWT with the entity claim shape
+  above.
+- OrionII installed from the bundle phones home, pulls policy, and chats through `/api/llm/generate`.
+- Per-agent events page shows ack'd egress within 5 seconds.
+- Deleting an agent revokes its tokens; the next OrionII call returns 401.

--- a/docs/runbooks/local-orion-sao-mvp.md
+++ b/docs/runbooks/local-orion-sao-mvp.md
@@ -1,0 +1,208 @@
+# Local OrionII + SAO MVP Runbook
+
+End-to-end walkthrough: log in → admin configures Ollama → user creates an entity → downloads the
+bundle → installs OrionII → entity phones home and chats through the SAO LLM proxy.
+
+## Prerequisites
+
+- Rust stable, Node.js 24, npm, Docker Desktop, PowerShell.
+- SAO checked out at `C:\Repo\SAO`, OrionII at `C:\Repo\OrionII`.
+- A locally running Ollama (or a Docker-network-reachable one) — required for the closed loop.
+- A local-only `SAO_JWT_SECRET` shared across SAO and OrionII (for the dev fallback path; the
+  bundle flow is fully self-contained once the bundle is downloaded).
+
+## 1. Build the OrionII installer (one-time per code change)
+
+The bundle endpoint serves a real `.msi`. Build it before the first run:
+
+```powershell
+cd C:\Repo\OrionII
+npm ci
+npm run tauri build -- --bundles msi
+```
+
+This produces an installer at:
+
+```
+C:\Repo\OrionII\src-tauri\target\release\bundle\msi\OrionII_0.1.0_x64_en-US.msi
+```
+
+## 2. Start SAO with the installer mount
+
+The SAO container can't see host filesystem paths, so we mount the OrionII MSI directory into
+the container and tell the bundle endpoint where to find it:
+
+```powershell
+cd C:\Repo\SAO
+$env:POSTGRES_PASSWORD            = "local-dev-only-change-me"
+$env:SAO_JWT_SECRET               = "local-dev-only-change-me"
+$env:SAO_LOCAL_BOOTSTRAP          = "true"
+$env:SAO_LOCAL_ADMIN_USERNAME     = "local-admin"
+# Bundle endpoint config — embedded in every config.json:
+$env:SAO_PUBLIC_BASE_URL          = "http://localhost:3100"
+# Installer mount (host path) + filename — Compose mounts this dir read-only at /installer:
+$env:SAO_ORION_INSTALLER_DIR      = "C:\Repo\OrionII\src-tauri\target\release\bundle\msi"
+$env:SAO_ORION_INSTALLER_FILENAME = "OrionII_0.1.0_x64_en-US.msi"
+
+docker compose -f docker\docker-compose.yml up --build
+```
+
+If you're not yet ready to serve installers, omit `SAO_ORION_INSTALLER_DIR` —
+Compose falls back to an empty placeholder mount, and the bundle endpoint returns a 503 with a
+clear remediation message until you stage the MSI.
+
+In a second window, run the bootstrap:
+
+```powershell
+cd C:\Repo\SAO
+$env:POSTGRES_PASSWORD            = "local-dev-only-change-me"
+$env:SAO_JWT_SECRET               = "local-dev-only-change-me"
+$env:SAO_LOCAL_BOOTSTRAP          = "true"
+$env:SAO_LOCAL_VAULT_PASSPHRASE   = "local-dev-only-change-me"
+$env:SAO_LOCAL_ADMIN_USERNAME     = "local-admin"
+docker compose -f docker\docker-compose.yml run --rm sao sao-server bootstrap-local
+```
+
+Browse to `http://localhost:3100`, register Windows Hello for `local-admin`, then sign in.
+
+## 3. (Admin) Configure LLM providers
+
+Go to **/admin/llm-providers**. Each provider has its own card. Configure as many as you want;
+entities pick one at creation time and SAO routes their `/api/llm/generate` calls to it.
+
+### Cloud providers (OpenAI, Anthropic Claude, xAI Grok, Google Gemini)
+
+For each one you want to enable:
+
+1. Get an API key from the provider console linked under the key field:
+   - OpenAI: `sk-...` from https://platform.openai.com/api-keys
+   - Anthropic: `sk-ant-...` from https://console.anthropic.com/settings/keys
+   - Grok: `xai-...` from https://console.x.ai/
+   - Gemini: `AIza...` from https://aistudio.google.com/apikey
+2. Toggle **Enabled** on.
+3. Paste the key into **API key** (write-only — never returned by GET).
+4. Tick the preset models you want to allow, or paste comma-separated overrides.
+5. Set **Default model** (auto-filled from the provider's preset).
+6. Click **Save**. The vault encrypts the key at rest under
+   `(provider=<name>, label='api_key', secret_type='api_key')`.
+7. Click **Test connection** — SAO sends a tiny ping prompt through the real provider path and
+   surfaces the latency + preview text or the upstream error.
+
+### Ollama (local self-hosted)
+
+1. Toggle **Enabled** on.
+2. Set base URL — from the SAO container, the host's Ollama is at
+   `http://host.docker.internal:11434`.
+3. Click **Refresh models** — the live `/api/tags` response populates a checkbox list.
+4. Tick the models you want to allow.
+5. Set **Default model** (e.g., `llama3.2`).
+6. Click **Save**, then **Test connection**.
+
+> Whichever provider you enable, the entity always calls SAO. There is no direct entity → upstream
+> path. Switching providers, rotating a key, or revoking a token in SAO applies instantly without
+> touching any installed entity.
+
+## 4. (User) Create an entity
+
+Go to **/agents** → **+ Register Agent**:
+
+1. **Name**: e.g. `abigail`.
+2. **LLM Provider**: choose `ollama`.
+3. **Id model** / **Ego model**: `llama3.2` (autofills from provider default).
+4. Click **Register**.
+
+A new card appears with the agent's UUID, `LLM: ollama / llama3.2 / llama3.2`, status `offline`.
+
+## 5. (User) Download the bundle
+
+Click **Download bundle** on the agent card. A file like
+`Orion-abigail-12345678.zip` downloads. Inside:
+
+| File | Purpose |
+|---|---|
+| `config.json` | SAO base URL, agent_id, **entity JWT**, default models. |
+| `OrionII-Setup.msi` | Tauri installer. |
+| `README-FIRST-RUN.txt` | Install steps. |
+
+The download mints a fresh entity JWT, revokes any prior tokens for that agent, and audit-logs
+`agents.bundle_downloaded`.
+
+## 6. Install + run OrionII
+
+1. Run `OrionII-Setup.msi` and finish the install wizard.
+2. Drop `config.json` into `%APPDATA%\OrionII\config.json` (create the folder if needed).
+   The bootstrap loader also accepts `config.json` co-located with the executable.
+3. Launch OrionII.
+
+On first launch:
+- Bootstrap reads `config.json` and adopts the SAO-assigned `agent_id` as the local
+  `orion_id`.
+- The model router is configured for `SaoProxyWithFallback` against the chosen provider.
+- The first chat call goes out as `POST {sao_base_url}/api/llm/generate` with the entity JWT.
+
+Type a message in OrionII; you should see a real response from `llama3.2` proxied through SAO.
+
+## 7. Verify the loop
+
+Back in SAO:
+
+- **/agents** — the badge should turn `active` after the first egress event lands.
+- Click **Logs** on the agent card → **/agents/:id/events** — see `identitySync`, `auditAction`,
+  and (if you indexed a doc) `memoryEvent` rows trickle in (page polls every 5s).
+- **/audit** — see `llm.generate`, `agents.bundle_downloaded`, `orion.egress` rows attributed to
+  the human owner with the agent_id surfaced.
+
+## 8. Re-issue / revoke
+
+- **Re-download**: clicking **Download bundle** again revokes the old token and mints a new
+  one — install the new config.json and restart OrionII.
+- **Delete**: deleting the agent in SAO bulk-revokes all tokens for that agent. The next
+  `/api/orion/policy` or `/api/llm/generate` call from the old install returns 401.
+
+## Dev/legacy fallback flow (no bundle)
+
+The original env-driven path still works for development:
+
+```powershell
+cd C:\Repo\OrionII
+$env:SAO_BASE_URL          = "http://localhost:3100"
+$env:SAO_DEV_BEARER_TOKEN  = (docker compose -f C:\Repo\SAO\docker\docker-compose.yml run --rm sao sao-server mint-dev-token | Select-Object -Last 1)
+$env:SAO_AGENT_ID          = "<optional>"
+npm run tauri dev
+```
+
+In this mode the bearer is a user JWT (admin acting as the entity) and the model layer falls back
+to local Ollama (no SAO LLM proxy). Useful for iterating on OrionII before rebuilding the MSI.
+
+## Troubleshooting
+
+- `503 OrionII installer is not staged` from the bundle endpoint — set
+  `SAO_ORION_INSTALLER_DIR` + `SAO_ORION_INSTALLER_FILENAME` and re-run `docker compose up`
+  (the directory is mounted into the container at `/installer`).
+- `400 Agent has no default LLM provider configured` — the agent was created before the wizard
+  fields existed. Delete and recreate it.
+- `400 Configured provider is currently disabled` — admin disabled the provider after the agent
+  was created. Re-enable in `/admin/llm-providers`.
+- Ollama probe returns `connection refused` from the SAO container — use
+  `http://host.docker.internal:11434` instead of `127.0.0.1`.
+- SAO LLM proxy returns 502 with `connection refused` — same fix; check the OrionII container
+  can reach the host's Ollama.
+- Entity JWT decoded but **revoked** — someone deleted the agent or downloaded a fresh bundle.
+  Download again.
+
+## Validation Gate
+
+Run before calling MVP green:
+
+```powershell
+cd C:\Repo\SAO
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+npm --prefix frontend test
+
+cd C:\Repo\OrionII
+npm ci
+npm run build
+cargo test --manifest-path src-tauri\Cargo.toml --locked
+cargo clippy --manifest-path src-tauri\Cargo.toml --locked -- -D warnings
+```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,8 @@ import AdminSsoPage from './pages/AdminSsoPage';
 import AuditLogPage from './pages/AuditLogPage';
 import SkillsCatalogPage from './pages/SkillsCatalogPage';
 import AdminSkillReviewPage from './pages/AdminSkillReviewPage';
+import AdminLlmProvidersPage from './pages/AdminLlmProvidersPage';
+import AgentEventsPage from './pages/AgentEventsPage';
 
 function AppRoutes() {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
@@ -61,6 +63,7 @@ function AppRoutes() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/vault" element={<VaultPage />} />
         <Route path="/agents" element={<AgentsPage />} />
+        <Route path="/agents/:id/events" element={<AgentEventsPage />} />
         <Route path="/skills" element={<SkillsCatalogPage />} />
         <Route path="/audit" element={<AuditLogPage />} />
         <Route
@@ -84,6 +87,14 @@ function AppRoutes() {
           element={
             <ProtectedRoute admin>
               <AdminSkillReviewPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/admin/llm-providers"
+          element={
+            <ProtectedRoute admin>
+              <AdminLlmProvidersPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -1,15 +1,29 @@
-import { apiRequest } from './client';
-import type { Agent, AgentBirthResponse, AgentStatusResponse } from '../types';
+import { apiRequest, ApiError } from './client';
+import type {
+  Agent,
+  AgentBirthResponse,
+  AgentEgressEvent,
+  AgentStatusResponse,
+} from '../types';
+
+export interface CreateAgentInput {
+  name: string;
+  default_provider?: string;
+  default_id_model?: string;
+  default_ego_model?: string;
+}
 
 export async function listAgents(): Promise<Agent[]> {
   const response = await apiRequest<{ agents: Agent[] }>('/api/agents');
   return response.agents;
 }
 
-export async function createAgent(name: string): Promise<AgentBirthResponse> {
+export async function createAgent(
+  input: CreateAgentInput,
+): Promise<AgentBirthResponse> {
   return apiRequest<AgentBirthResponse>('/api/agents', {
     method: 'POST',
-    body: JSON.stringify({ name }),
+    body: JSON.stringify(input),
   });
 }
 
@@ -18,7 +32,53 @@ export async function getAgent(id: string): Promise<AgentStatusResponse> {
 }
 
 export async function deleteAgent(id: string): Promise<void> {
-  return apiRequest<void>(`/api/agents/${id}`, {
-    method: 'DELETE',
+  return apiRequest<void>(`/api/agents/${id}/delete`, {
+    method: 'POST',
   });
+}
+
+export async function listAgentEvents(
+  id: string,
+  limit = 50,
+  offset = 0,
+): Promise<AgentEgressEvent[]> {
+  const response = await apiRequest<{
+    events: AgentEgressEvent[];
+    limit: number;
+    offset: number;
+  }>(`/api/agents/${id}/events?limit=${limit}&offset=${offset}`);
+  return response.events;
+}
+
+export async function downloadAgentBundle(id: string, name: string): Promise<void> {
+  const csrf = document.cookie
+    .split(';')
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith('sao_csrf='));
+  const csrfToken = csrf
+    ? decodeURIComponent(csrf.slice('sao_csrf='.length))
+    : '';
+
+  const res = await fetch(`/api/agents/${id}/bundle`, {
+    credentials: 'include',
+    headers: csrfToken ? { 'X-CSRF-Token': csrfToken } : {},
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(res.status, text);
+  }
+  const blob = await res.blob();
+
+  const safeName = name.replace(/[^a-zA-Z0-9]/g, '-');
+  const shortId = id.slice(0, 8);
+  const filename = `Orion-${safeName}-${shortId}.zip`;
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }

--- a/frontend/src/api/api-contracts.test.ts
+++ b/frontend/src/api/api-contracts.test.ts
@@ -5,7 +5,8 @@ import {
   queryAuditLog,
 } from './admin';
 import { listSecrets } from './vault';
-import { webauthnLoginStart } from './auth';
+import { getMe, webauthnLoginStart } from './auth';
+import { deleteAgent } from './agents';
 
 type MockResponse = {
   ok: boolean;
@@ -141,6 +142,36 @@ describe('frontend api contract adapters', () => {
       expect.objectContaining({
         headers: expect.any(Object),
         credentials: 'include',
+      }),
+    );
+  });
+
+  it('does not refresh or hard reload when auth discovery is unauthenticated', async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ error: 'Authentication required' }, 401));
+
+    await expect(getMe()).rejects.toThrow('API error 401');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/me',
+      expect.objectContaining({
+        credentials: 'include',
+      }),
+    );
+  });
+
+  it('sends agent delete requests to the browser-safe action endpoint', async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ deleted: true }));
+
+    await deleteAgent('agent-1');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/agents/agent-1/delete',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: expect.objectContaining({
+          'X-CSRF-Token': 'test-csrf-token',
+        }),
       }),
     );
   });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -4,6 +4,10 @@ import type {
   SetupStatus,
   User,
 } from '../types';
+import type {
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+} from '@simplewebauthn/types';
 
 export async function setupStatus(): Promise<SetupStatus> {
   return apiRequest<SetupStatus>('/api/setup/status');
@@ -11,10 +15,10 @@ export async function setupStatus(): Promise<SetupStatus> {
 
 export async function webauthnRegisterStart(
   username: string,
-): Promise<{ challenge_id: string; options: PublicKeyCredentialCreationOptions }> {
+): Promise<{ challenge_id: string; options: PublicKeyCredentialCreationOptionsJSON | { publicKey: PublicKeyCredentialCreationOptionsJSON } }> {
   const res = await apiRequest<{
     challenge_id: string;
-    challenge: PublicKeyCredentialCreationOptions;
+    challenge: PublicKeyCredentialCreationOptionsJSON | { publicKey: PublicKeyCredentialCreationOptionsJSON };
   }>('/api/auth/webauthn/register/start', {
     method: 'POST',
     body: JSON.stringify({ username }),
@@ -35,12 +39,38 @@ export async function webauthnRegisterFinish(
   );
 }
 
-export async function webauthnLoginStart(
+export async function localWebauthnRegisterStart(
   username?: string,
-): Promise<{ challenge_id: string; options: PublicKeyCredentialRequestOptions }> {
+): Promise<{ challenge_id: string; options: PublicKeyCredentialCreationOptionsJSON | { publicKey: PublicKeyCredentialCreationOptionsJSON } }> {
   const res = await apiRequest<{
     challenge_id: string;
-    challenge: PublicKeyCredentialRequestOptions;
+    challenge: PublicKeyCredentialCreationOptionsJSON | { publicKey: PublicKeyCredentialCreationOptionsJSON };
+  }>('/api/auth/webauthn/local/register/start', {
+    method: 'POST',
+    body: JSON.stringify({ username }),
+  });
+  return { challenge_id: res.challenge_id, options: res.challenge };
+}
+
+export async function localWebauthnRegisterFinish(
+  challenge_id: string,
+  credential: unknown,
+): Promise<{ status: string; credential_id: string }> {
+  return apiRequest<{ status: string; credential_id: string }>(
+    '/api/auth/webauthn/local/register/finish',
+    {
+      method: 'POST',
+      body: JSON.stringify({ challenge_id, credential }),
+    },
+  );
+}
+
+export async function webauthnLoginStart(
+  username?: string,
+): Promise<{ challenge_id: string; options: PublicKeyCredentialRequestOptionsJSON | { publicKey: PublicKeyCredentialRequestOptionsJSON } }> {
+  const res = await apiRequest<{
+    challenge_id: string;
+    challenge: PublicKeyCredentialRequestOptionsJSON | { publicKey: PublicKeyCredentialRequestOptionsJSON };
   }>('/api/auth/webauthn/login/start', {
     method: 'POST',
     body: JSON.stringify({ username }),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,7 @@ const CSRF_COOKIE_NAME = 'sao_csrf';
 
 let isRefreshing = false;
 let refreshSubscribers: Array<() => void> = [];
+const NO_REFRESH_PATHS = new Set(['/api/auth/me', '/api/auth/refresh']);
 
 function onRefreshed() {
   refreshSubscribers.forEach((cb) => cb());
@@ -73,7 +74,7 @@ export async function apiRequest<T>(
     headers,
   });
 
-  if (res.status === 401 && path !== '/api/auth/refresh') {
+  if (res.status === 401 && !NO_REFRESH_PATHS.has(path)) {
     if (!isRefreshing) {
       isRefreshing = true;
       const refreshed = await attemptSessionRefresh();

--- a/frontend/src/api/llm-providers.ts
+++ b/frontend/src/api/llm-providers.ts
@@ -1,0 +1,47 @@
+import { apiRequest } from './client';
+import type {
+  LlmProvider,
+  LlmProviderTestResult,
+  UpdateLlmProviderData,
+} from '../types';
+
+export async function listLlmProviders(): Promise<LlmProvider[]> {
+  const response = await apiRequest<{ providers: LlmProvider[] }>(
+    '/api/admin/llm-providers',
+  );
+  return response.providers;
+}
+
+export async function updateLlmProvider(
+  provider: string,
+  data: UpdateLlmProviderData,
+): Promise<LlmProvider> {
+  return apiRequest<LlmProvider>(`/api/admin/llm-providers/${provider}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function probeOllamaModels(baseUrl: string): Promise<string[]> {
+  const response = await apiRequest<{ models: string[] }>(
+    '/api/admin/llm-providers/ollama/probe',
+    {
+      method: 'POST',
+      body: JSON.stringify({ base_url: baseUrl }),
+    },
+  );
+  return response.models;
+}
+
+export async function testLlmProvider(
+  provider: string,
+  model?: string,
+): Promise<LlmProviderTestResult> {
+  return apiRequest<LlmProviderTestResult>(
+    `/api/admin/llm-providers/${provider}/test`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ model }),
+    },
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -68,6 +68,7 @@ export default function Layout() {
               <SidebarLink to="/admin/users" label="Users" icon="[U]" />
               <SidebarLink to="/admin/sso" label="SSO" icon="[S]" />
               <SidebarLink to="/admin/skills/review" label="Skill Reviews" icon="[R]" />
+              <SidebarLink to="/admin/llm-providers" label="LLM Providers" icon="[M]" />
             </>
           )}
         </nav>

--- a/frontend/src/lib/webauthn.ts
+++ b/frontend/src/lib/webauthn.ts
@@ -8,13 +8,25 @@ import type {
 } from '@simplewebauthn/types';
 
 export async function beginRegistration(
-  options: PublicKeyCredentialCreationOptionsJSON,
+  options: PublicKeyCredentialCreationOptionsJSON | { publicKey: PublicKeyCredentialCreationOptionsJSON },
 ) {
-  return startRegistration(options);
+  return startRegistration(unwrapPublicKeyOptions(options));
 }
 
 export async function beginAuthentication(
-  options: PublicKeyCredentialRequestOptionsJSON,
+  options: PublicKeyCredentialRequestOptionsJSON | { publicKey: PublicKeyCredentialRequestOptionsJSON },
 ) {
-  return startAuthentication(options);
+  return startAuthentication(unwrapPublicKeyOptions(options));
+}
+
+function unwrapPublicKeyOptions<T>(options: T | { publicKey: T }): T {
+  if (
+    typeof options === 'object' &&
+    options !== null &&
+    'publicKey' in options
+  ) {
+    return options.publicKey;
+  }
+
+  return options;
 }

--- a/frontend/src/pages/AdminLlmProvidersPage.tsx
+++ b/frontend/src/pages/AdminLlmProvidersPage.tsx
@@ -1,0 +1,426 @@
+import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  listLlmProviders,
+  probeOllamaModels,
+  testLlmProvider,
+  updateLlmProvider,
+} from '../api/llm-providers';
+import type {
+  LlmProvider,
+  LlmProviderName,
+  LlmProviderTestResult,
+} from '../types';
+
+interface ProviderCatalogEntry {
+  name: LlmProviderName;
+  label: string;
+  blurb: string;
+  needsKey: boolean;
+  needsBaseUrl: boolean;
+  keyHint?: string;
+  consoleUrl?: string;
+  presetModels: string[];
+  defaultModel: string;
+}
+
+const CATALOG: ProviderCatalogEntry[] = [
+  {
+    name: 'openai',
+    label: 'OpenAI',
+    blurb: 'GPT-4o family. Used by entities that need general-purpose chat or tool-use.',
+    needsKey: true,
+    needsBaseUrl: false,
+    keyHint: 'sk-... — create at platform.openai.com/api-keys',
+    consoleUrl: 'https://platform.openai.com/api-keys',
+    presetModels: ['gpt-4o', 'gpt-4o-mini', 'gpt-4.1', 'gpt-4.1-mini'],
+    defaultModel: 'gpt-4o-mini',
+  },
+  {
+    name: 'anthropic',
+    label: 'Anthropic Claude',
+    blurb: 'Claude 4.x family. Strong reasoning, large context, computer-use compatible.',
+    needsKey: true,
+    needsBaseUrl: false,
+    keyHint: 'sk-ant-... — create at console.anthropic.com/settings/keys',
+    consoleUrl: 'https://console.anthropic.com/settings/keys',
+    presetModels: [
+      'claude-opus-4-7',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5-20251001',
+    ],
+    defaultModel: 'claude-haiku-4-5-20251001',
+  },
+  {
+    name: 'grok',
+    label: 'xAI Grok',
+    blurb: 'Grok 4 family from xAI. OpenAI-compatible chat completions.',
+    needsKey: true,
+    needsBaseUrl: false,
+    keyHint: 'xai-... — create at console.x.ai',
+    consoleUrl: 'https://console.x.ai/',
+    presetModels: ['grok-4-latest', 'grok-4-fast', 'grok-3'],
+    defaultModel: 'grok-4-fast',
+  },
+  {
+    name: 'gemini',
+    label: 'Google Gemini',
+    blurb: 'Gemini 2.x via the Generative Language API.',
+    needsKey: true,
+    needsBaseUrl: false,
+    keyHint: 'AIza... — create at aistudio.google.com/apikey',
+    consoleUrl: 'https://aistudio.google.com/apikey',
+    presetModels: [
+      'gemini-2.5-pro',
+      'gemini-2.5-flash',
+      'gemini-2.0-flash',
+    ],
+    defaultModel: 'gemini-2.5-flash',
+  },
+  {
+    name: 'ollama',
+    label: 'Ollama (local)',
+    blurb:
+      'Self-hosted models. SAO probes /api/tags on the URL you provide and proxies generations to it.',
+    needsKey: false,
+    needsBaseUrl: true,
+    presetModels: ['llama3.2', 'qwen3:8b', 'mistral'],
+    defaultModel: 'llama3.2',
+  },
+];
+
+export default function AdminLlmProvidersPage() {
+  const { data: providers, isLoading } = useQuery({
+    queryKey: ['llm-providers'],
+    queryFn: listLlmProviders,
+  });
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-white mb-2">LLM Providers</h1>
+      <p className="text-sm text-gray-400 mb-6 max-w-3xl">
+        Provider keys live in the SAO vault and never leave the server. Every OrionII entity
+        proxies through SAO via{' '}
+        <span className="font-mono text-gray-300">POST /api/llm/generate</span>; switching
+        providers, rotating a key, or revoking a token applies instantly without redeploying any
+        entity.
+      </p>
+
+      {isLoading ? (
+        <div className="text-gray-400">Loading...</div>
+      ) : (
+        <div className="space-y-6">
+          {CATALOG.map((entry) => (
+            <ProviderCard
+              key={entry.name}
+              entry={entry}
+              row={providers?.find((p) => p.provider === entry.name)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProviderCard({
+  entry,
+  row,
+}: {
+  entry: ProviderCatalogEntry;
+  row: LlmProvider | undefined;
+}) {
+  const queryClient = useQueryClient();
+  const [enabled, setEnabled] = useState(row?.enabled ?? false);
+  const [baseUrl, setBaseUrl] = useState(row?.base_url ?? '');
+  const [defaultModel, setDefaultModel] = useState(
+    row?.default_model ?? entry.defaultModel,
+  );
+  const [approvedModels, setApprovedModels] = useState<string[]>(
+    row?.approved_models?.length
+      ? row.approved_models
+      : entry.needsKey || entry.needsBaseUrl
+        ? []
+        : entry.presetModels,
+  );
+  const [apiKey, setApiKey] = useState('');
+  const [discovered, setDiscovered] = useState<string[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [saved, setSaved] = useState(false);
+  const [testResult, setTestResult] = useState<LlmProviderTestResult | null>(null);
+
+  useEffect(() => {
+    if (!row) return;
+    setEnabled(row.enabled);
+    setBaseUrl(row.base_url ?? '');
+    setDefaultModel(row.default_model ?? entry.defaultModel);
+    if (row.approved_models?.length) {
+      setApprovedModels(row.approved_models);
+    }
+  }, [row, entry.defaultModel]);
+
+  const togglePreset = (model: string) => {
+    setApprovedModels((current) =>
+      current.includes(model)
+        ? current.filter((m) => m !== model)
+        : [...current, model],
+    );
+  };
+
+  const handleProbe = async () => {
+    setError('');
+    if (!baseUrl.trim()) {
+      setError('Base URL is required');
+      return;
+    }
+    setBusy(true);
+    try {
+      const models = await probeOllamaModels(baseUrl.trim());
+      setDiscovered(models);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Probe failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setError('');
+    setSaved(false);
+    setTestResult(null);
+    setBusy(true);
+    try {
+      await updateLlmProvider(entry.name, {
+        enabled,
+        base_url: entry.needsBaseUrl ? baseUrl.trim() : null,
+        approved_models: approvedModels,
+        default_model: defaultModel.trim() || null,
+        api_key: apiKey.trim() ? apiKey.trim() : undefined,
+      });
+      setApiKey('');
+      setSaved(true);
+      await queryClient.invalidateQueries({ queryKey: ['llm-providers'] });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setError('');
+    setSaved(false);
+    setTestResult(null);
+    setBusy(true);
+    try {
+      const result = await testLlmProvider(entry.name, defaultModel.trim() || undefined);
+      setTestResult(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Test failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const stored = row?.has_api_key;
+
+  return (
+    <div className="bg-gray-800 rounded-xl border border-gray-700 p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">{entry.label}</h2>
+          <p className="text-xs text-gray-400 mt-0.5 max-w-2xl">{entry.blurb}</p>
+        </div>
+        <label className="flex items-center gap-2 text-sm text-gray-300">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          Enabled
+        </label>
+      </div>
+
+      {entry.needsBaseUrl && (
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Base URL</label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="http://host.docker.internal:11434"
+              className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            />
+            <button
+              onClick={handleProbe}
+              disabled={busy}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded-lg"
+            >
+              Refresh models
+            </button>
+          </div>
+        </div>
+      )}
+
+      {entry.needsKey && (
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">
+            API key{' '}
+            {stored ? (
+              <span className="text-green-400">(stored — leave blank to keep)</span>
+            ) : (
+              <span className="text-yellow-400">(required)</span>
+            )}
+          </label>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={entry.keyHint ?? 'paste API key'}
+            autoComplete="off"
+            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+          />
+          {entry.consoleUrl && (
+            <p className="text-xs text-gray-500 mt-1">
+              Get a key:{' '}
+              <a
+                href={entry.consoleUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-blue-400 hover:underline"
+              >
+                {entry.consoleUrl}
+              </a>
+            </p>
+          )}
+        </div>
+      )}
+
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          Approved models — entities can only use models on this list
+        </label>
+        <div className="flex flex-wrap gap-2 mb-2">
+          {entry.presetModels.map((m) => (
+            <label
+              key={m}
+              className="flex items-center gap-2 px-2 py-1 bg-gray-700 rounded text-xs text-gray-200"
+            >
+              <input
+                type="checkbox"
+                checked={approvedModels.includes(m)}
+                onChange={() => togglePreset(m)}
+              />
+              <span className="font-mono">{m}</span>
+            </label>
+          ))}
+        </div>
+        {discovered && (
+          <div className="mb-2">
+            <p className="text-xs text-gray-500 mb-1">Discovered on Ollama:</p>
+            <div className="flex flex-wrap gap-2">
+              {discovered.length === 0 && (
+                <span className="text-xs text-gray-500">Ollama returned no models</span>
+              )}
+              {discovered.map((m) => (
+                <label
+                  key={m}
+                  className="flex items-center gap-2 px-2 py-1 bg-gray-700 rounded text-xs text-gray-200"
+                >
+                  <input
+                    type="checkbox"
+                    checked={approvedModels.includes(m)}
+                    onChange={() => togglePreset(m)}
+                  />
+                  <span className="font-mono">{m}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+        <input
+          type="text"
+          value={approvedModels.join(', ')}
+          onChange={(e) =>
+            setApprovedModels(
+              e.target.value
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean),
+            )
+          }
+          placeholder="comma-separated override (e.g., custom fine-tunes)"
+          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 text-xs font-mono"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">Default model</label>
+        <input
+          type="text"
+          value={defaultModel}
+          onChange={(e) => setDefaultModel(e.target.value)}
+          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono"
+        />
+      </div>
+
+      {error && (
+        <div className="rounded border border-red-800 bg-red-900/30 p-2 text-xs text-red-300">
+          {error}
+        </div>
+      )}
+      {saved && <div className="text-xs text-green-400">Saved.</div>}
+      {testResult && (
+        <div
+          className={`rounded border p-2 text-xs ${
+            testResult.ok
+              ? 'border-green-800 bg-green-900/30 text-green-200'
+              : 'border-red-800 bg-red-900/30 text-red-200'
+          }`}
+        >
+          {testResult.ok ? (
+            <>
+              <div>
+                ✓ {entry.label} replied in {testResult.latency_ms}ms via{' '}
+                <span className="font-mono">{testResult.model}</span>
+              </div>
+              {testResult.preview && (
+                <div className="mt-1 text-gray-300">
+                  preview: <span className="italic">{testResult.preview}</span>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              ✗ Test failed ({testResult.latency_ms}ms): {testResult.error}
+            </>
+          )}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={handleTest}
+          disabled={busy || (entry.needsKey && !stored && !apiKey.trim())}
+          title={
+            entry.needsKey && !stored && !apiKey.trim()
+              ? 'Save an API key first, then test.'
+              : 'Send a tiny ping prompt to verify connectivity.'
+          }
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 text-white text-sm rounded-lg"
+        >
+          {busy ? 'Working...' : 'Test connection'}
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={busy}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-900 text-white text-sm rounded-lg"
+        >
+          {busy ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AgentEventsPage.tsx
+++ b/frontend/src/pages/AgentEventsPage.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getAgent, listAgentEvents } from '../api/agents';
+
+const PAGE_SIZE = 25;
+
+function eventColor(type: string): string {
+  switch (type) {
+    case 'auditAction':
+      return 'text-blue-300';
+    case 'memoryEvent':
+      return 'text-purple-300';
+    case 'identitySync':
+      return 'text-emerald-300';
+    default:
+      return 'text-gray-300';
+  }
+}
+
+export default function AgentEventsPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [offset, setOffset] = useState(0);
+
+  const { data: agent } = useQuery({
+    queryKey: ['agent', id],
+    queryFn: () => getAgent(id!),
+    enabled: !!id,
+  });
+
+  const { data: events, isLoading } = useQuery({
+    queryKey: ['agent-events', id, offset],
+    queryFn: () => listAgentEvents(id!, PAGE_SIZE, offset),
+    enabled: !!id,
+    refetchInterval: 5000,
+  });
+
+  if (!id) return null;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <button
+            onClick={() => navigate('/agents')}
+            className="text-xs text-gray-400 hover:text-white mb-2"
+          >
+            ← Agents
+          </button>
+          <h1 className="text-2xl font-bold text-white">
+            Events — {agent ? agent.agent_id.slice(0, 8) : id.slice(0, 8)}
+          </h1>
+          {agent?.last_heartbeat && (
+            <p className="text-xs text-gray-400 mt-1">
+              Last heartbeat: {new Date(agent.last_heartbeat).toLocaleString()}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="text-gray-400">Loading...</div>
+      ) : (events ?? []).length === 0 ? (
+        <div className="text-center py-16 text-gray-500">
+          No egress events yet. Once the entity is installed and chats with
+          you, audit / memory / identitySync events will appear here.
+        </div>
+      ) : (
+        <div className="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-900 text-xs text-gray-400 uppercase">
+              <tr>
+                <th className="px-4 py-2 text-left">When</th>
+                <th className="px-4 py-2 text-left">Type</th>
+                <th className="px-4 py-2 text-left">Orion ID</th>
+                <th className="px-4 py-2 text-left">Payload</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(events ?? []).map((e) => (
+                <tr
+                  key={e.event_id}
+                  className="border-t border-gray-700 hover:bg-gray-700/40"
+                >
+                  <td className="px-4 py-2 text-gray-300 whitespace-nowrap">
+                    {new Date(e.created_at).toLocaleString()}
+                  </td>
+                  <td
+                    className={`px-4 py-2 font-mono ${eventColor(e.event_type)}`}
+                  >
+                    {e.event_type}
+                  </td>
+                  <td className="px-4 py-2 font-mono text-xs text-gray-400">
+                    {e.orion_id.slice(0, 8)}
+                  </td>
+                  <td className="px-4 py-2 text-xs text-gray-300">
+                    <pre className="whitespace-pre-wrap break-all max-w-xl">
+                      {JSON.stringify(e.payload, null, 2)}
+                    </pre>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between mt-4">
+        <button
+          onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+          disabled={offset === 0}
+          className="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-600 text-gray-200 rounded"
+        >
+          Previous
+        </button>
+        <span className="text-xs text-gray-500">
+          showing {offset + 1}–{offset + (events?.length ?? 0)}
+        </span>
+        <button
+          onClick={() => setOffset(offset + PAGE_SIZE)}
+          disabled={(events?.length ?? 0) < PAGE_SIZE}
+          className="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-600 text-gray-200 rounded"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -1,14 +1,26 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { listAgents, createAgent, deleteAgent } from '../api/agents';
-import type { Agent } from '../types';
+import {
+  listAgents,
+  createAgent,
+  deleteAgent,
+  downloadAgentBundle,
+} from '../api/agents';
+import { listLlmProviders } from '../api/llm-providers';
+import type { Agent, LlmProvider } from '../types';
 
 export default function AgentsPage() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [showRegister, setShowRegister] = useState(false);
   const [newAgentName, setNewAgentName] = useState('');
+  const [newProvider, setNewProvider] = useState('');
+  const [newIdModel, setNewIdModel] = useState('');
+  const [newEgoModel, setNewEgoModel] = useState('');
   const [error, setError] = useState('');
   const [creating, setCreating] = useState(false);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
@@ -17,38 +29,87 @@ export default function AgentsPage() {
     queryFn: listAgents,
   });
 
+  const { data: providers } = useQuery({
+    queryKey: ['llm-providers'],
+    queryFn: listLlmProviders,
+    // Non-admins can't read this; treat 403 as "no providers" gracefully.
+    retry: false,
+  });
+
+  const enabledProviders = useMemo<LlmProvider[]>(
+    () => (providers ?? []).filter((p) => p.enabled),
+    [providers],
+  );
+
+  const selectedProvider = useMemo(
+    () => enabledProviders.find((p) => p.provider === newProvider),
+    [enabledProviders, newProvider],
+  );
+
   const handleRegister = async () => {
     setError('');
     if (!newAgentName.trim()) {
       setError('Agent name is required');
       return;
     }
+    if (enabledProviders.length > 0) {
+      if (!newProvider) {
+        setError('Choose an LLM provider');
+        return;
+      }
+      if (!newIdModel.trim() || !newEgoModel.trim()) {
+        setError('Choose both Id and Ego models');
+        return;
+      }
+    }
 
     setCreating(true);
     try {
-      await createAgent(newAgentName.trim());
+      await createAgent({
+        name: newAgentName.trim(),
+        default_provider: newProvider || undefined,
+        default_id_model: newIdModel.trim() || undefined,
+        default_ego_model: newEgoModel.trim() || undefined,
+      });
       await queryClient.invalidateQueries({ queryKey: ['agents'] });
       setNewAgentName('');
+      setNewProvider('');
+      setNewIdModel('');
+      setNewEgoModel('');
       setShowRegister(false);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to register agent',
-      );
+      setError(err instanceof Error ? err.message : 'Failed to register agent');
     } finally {
       setCreating(false);
     }
   };
 
+  const handleDownload = async (agent: Agent) => {
+    setError('');
+    setDownloadingId(agent.id);
+    try {
+      await downloadAgentBundle(agent.id, agent.name);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to download bundle',
+      );
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
   const handleDelete = async (id: string) => {
+    setError('');
     setDeletingId(id);
     try {
       await deleteAgent(id);
+      queryClient.setQueryData<Agent[]>(['agents'], (current) =>
+        current?.filter((agent) => agent.id !== id) ?? [],
+      );
       await queryClient.invalidateQueries({ queryKey: ['agents'] });
       setConfirmDeleteId(null);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to delete agent',
-      );
+      setError(err instanceof Error ? err.message : 'Failed to delete agent');
     } finally {
       setDeletingId(null);
     }
@@ -81,21 +142,89 @@ export default function AgentsPage() {
         </button>
       </div>
 
-      {/* Register Agent Form */}
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-800 bg-red-900/30 p-3">
+          <p className="text-sm text-red-300">{error}</p>
+        </div>
+      )}
+
       {showRegister && (
-        <div className="bg-gray-800 rounded-xl border border-gray-700 p-6 mb-6">
-          <h2 className="text-lg font-semibold text-white mb-4">
+        <div className="bg-gray-800 rounded-xl border border-gray-700 p-6 mb-6 space-y-4">
+          <h2 className="text-lg font-semibold text-white">
             Register New Agent
           </h2>
-          <div className="flex gap-3">
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">Name</label>
             <input
               type="text"
               value={newAgentName}
               onChange={(e) => setNewAgentName(e.target.value)}
-              placeholder="Agent name (e.g., abigail-main)"
-              onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
-              className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+              placeholder="abigail-main"
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
             />
+          </div>
+
+          {enabledProviders.length === 0 ? (
+            <div className="rounded-lg border border-yellow-800 bg-yellow-900/20 p-3 text-sm text-yellow-200">
+              No LLM providers are enabled. Ask an administrator to configure one
+              under <span className="font-mono">/admin/llm-providers</span>.
+            </div>
+          ) : (
+            <>
+              <div>
+                <label className="block text-xs text-gray-400 mb-1">
+                  LLM Provider
+                </label>
+                <select
+                  value={newProvider}
+                  onChange={(e) => {
+                    setNewProvider(e.target.value);
+                    const p = enabledProviders.find(
+                      (x) => x.provider === e.target.value,
+                    );
+                    if (p?.default_model) {
+                      setNewIdModel(p.default_model);
+                      setNewEgoModel(p.default_model);
+                    }
+                  }}
+                  className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:outline-none focus:border-blue-500"
+                >
+                  <option value="">Choose provider...</option>
+                  {enabledProviders.map((p) => (
+                    <option key={p.provider} value={p.provider}>
+                      {p.provider}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs text-gray-400 mb-1">
+                    Id model
+                  </label>
+                  <ModelInput
+                    value={newIdModel}
+                    onChange={setNewIdModel}
+                    options={selectedProvider?.approved_models ?? []}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-400 mb-1">
+                    Ego model
+                  </label>
+                  <ModelInput
+                    value={newEgoModel}
+                    onChange={setNewEgoModel}
+                    options={selectedProvider?.approved_models ?? []}
+                  />
+                </div>
+              </div>
+            </>
+          )}
+
+          <div className="flex gap-3">
             <button
               onClick={handleRegister}
               disabled={creating}
@@ -107,6 +236,9 @@ export default function AgentsPage() {
               onClick={() => {
                 setShowRegister(false);
                 setNewAgentName('');
+                setNewProvider('');
+                setNewIdModel('');
+                setNewEgoModel('');
                 setError('');
               }}
               className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 font-medium rounded-lg transition-colors"
@@ -114,11 +246,9 @@ export default function AgentsPage() {
               Cancel
             </button>
           </div>
-          {error && <p className="text-red-400 text-sm mt-2">{error}</p>}
         </div>
       )}
 
-      {/* Agent List */}
       {isLoading ? (
         <div className="text-center py-16 text-gray-400">
           Loading agents...
@@ -147,6 +277,16 @@ export default function AgentsPage() {
                 </div>
               </div>
 
+              {agent.default_provider && (
+                <div className="mb-3 text-xs text-gray-300">
+                  <span className="text-gray-500">LLM:</span>{' '}
+                  <span className="font-mono">
+                    {agent.default_provider} / {agent.default_id_model} /{' '}
+                    {agent.default_ego_model}
+                  </span>
+                </div>
+              )}
+
               {agent.capabilities.length > 0 && (
                 <div className="flex flex-wrap gap-1.5 mb-3">
                   {agent.capabilities.map((cap) => (
@@ -160,43 +300,54 @@ export default function AgentsPage() {
                 </div>
               )}
 
-              {agent.public_key && (
-                <div className="mb-3">
-                  <p className="text-xs text-gray-500">Public Key</p>
-                  <p className="text-xs text-gray-400 font-mono truncate">
-                    {agent.public_key}
-                  </p>
-                </div>
-              )}
-
-              <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-700">
-                <span className="text-xs text-gray-500">
-                  Created {new Date(agent.created_at).toLocaleDateString()}
-                </span>
+              <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-gray-700">
+                <button
+                  onClick={() => handleDownload(agent)}
+                  disabled={downloadingId === agent.id}
+                  className="text-xs px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-900 text-white rounded transition-colors"
+                >
+                  {downloadingId === agent.id ? 'Building...' : 'Download bundle'}
+                </button>
+                <button
+                  onClick={() => navigate(`/agents/${agent.id}/events`)}
+                  className="text-xs px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded transition-colors"
+                >
+                  Logs
+                </button>
                 {confirmDeleteId === agent.id ? (
-                  <div className="flex gap-2">
+                  <div className="flex gap-2 ml-auto">
                     <button
                       onClick={() => handleDelete(agent.id)}
                       disabled={deletingId === agent.id}
-                      className="text-xs px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded transition-colors"
+                      className="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 disabled:bg-red-900 text-white rounded transition-colors"
                     >
-                      {deletingId === agent.id ? '...' : 'Confirm'}
+                      {deletingId === agent.id
+                        ? 'Deleting...'
+                        : 'Confirm delete'}
                     </button>
                     <button
                       onClick={() => setConfirmDeleteId(null)}
-                      className="text-xs px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition-colors"
+                      disabled={deletingId === agent.id}
+                      className="text-xs px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition-colors"
                     >
                       Cancel
                     </button>
                   </div>
                 ) : (
                   <button
-                    onClick={() => setConfirmDeleteId(agent.id)}
-                    className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                    onClick={() => {
+                      setError('');
+                      setConfirmDeleteId(agent.id);
+                    }}
+                    className="text-xs px-3 py-1.5 text-red-400 hover:text-red-300 ml-auto"
                   >
                     Delete
                   </button>
                 )}
+              </div>
+
+              <div className="text-xs text-gray-500 mt-2">
+                Created {new Date(agent.created_at).toLocaleDateString()}
               </div>
             </div>
           ))}
@@ -213,5 +364,36 @@ export default function AgentsPage() {
         </div>
       )}
     </div>
+  );
+}
+
+function ModelInput({
+  value,
+  onChange,
+  options,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: string[];
+}) {
+  const listId = `models-${Math.random().toString(36).slice(2, 9)}`;
+  return (
+    <>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        list={options.length > 0 ? listId : undefined}
+        placeholder="model name"
+        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+      />
+      {options.length > 0 && (
+        <datalist id={listId}>
+          {options.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
+      )}
+    </>
   );
 }

--- a/frontend/src/pages/BootstrapRequiredPage.tsx
+++ b/frontend/src/pages/BootstrapRequiredPage.tsx
@@ -7,8 +7,13 @@ interface BootstrapRequiredPageProps {
 export default function BootstrapRequiredPage({
   status,
 }: BootstrapRequiredPageProps) {
-  const command =
+  const commands = status?.recommended_installer?.commands;
+  const powershellCommand =
+    commands?.powershell ||
     status?.recommended_installer?.command ||
+    'cd C:\\Repo\\SAO\ndocker build -f installer/Dockerfile -t sao-installer installer\ndocker run --rm -it -e ANTHROPIC_API_KEY="<your-key>" sao-installer';
+  const bashCommand =
+    commands?.bash ||
     'docker build -f installer/Dockerfile -t sao-installer installer && docker run --rm -it -e ANTHROPIC_API_KEY=<your-key> sao-installer';
 
   return (
@@ -30,10 +35,19 @@ export default function BootstrapRequiredPage({
         <div className="grid gap-0 lg:grid-cols-[1.4fr_1fr]">
           <div className="px-8 py-8 border-b lg:border-b-0 lg:border-r border-slate-800">
             <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
-              One-command start
+              Bootstrap commands
             </h2>
+            <p className="mt-4 text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300">
+              Windows PowerShell
+            </p>
             <pre className="mt-4 rounded-2xl border border-slate-800 bg-slate-950/80 p-5 text-sm text-cyan-100 overflow-x-auto whitespace-pre-wrap">
-              <code>{command}</code>
+              <code>{powershellCommand}</code>
+            </pre>
+            <p className="mt-4 text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300">
+              Bash
+            </p>
+            <pre className="mt-4 rounded-2xl border border-slate-800 bg-slate-950/80 p-5 text-sm text-cyan-100 overflow-x-auto whitespace-pre-wrap">
+              <code>{bashCommand}</code>
             </pre>
             <p className="mt-4 text-sm text-slate-400">
               The installer handles Azure sign-in, subscription targeting,

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -2,11 +2,13 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import {
+  localWebauthnRegisterFinish,
+  localWebauthnRegisterStart,
   webauthnLoginStart,
   webauthnLoginFinish,
   listAuthOidcProviders,
 } from '../api/auth';
-import { beginAuthentication } from '../lib/webauthn';
+import { beginAuthentication, beginRegistration } from '../lib/webauthn';
 import type { OidcProvider } from '../types';
 
 export default function Login() {
@@ -16,7 +18,9 @@ export default function Login() {
 
   const [username, setUsername] = useState('');
   const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
   const [loading, setLoading] = useState(false);
+  const [registering, setRegistering] = useState(false);
   const [oidcProviders, setOidcProviders] = useState<OidcProvider[]>([]);
 
   const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/';
@@ -39,6 +43,7 @@ export default function Login() {
 
   const handleWebAuthnLogin = async () => {
     setError('');
+    setNotice('');
     setLoading(true);
     try {
       const requestedUsername = username.trim();
@@ -57,6 +62,32 @@ export default function Login() {
       );
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleLocalRegistration = async () => {
+    setError('');
+    setNotice('');
+    setRegistering(true);
+    try {
+      const requestedUsername = username.trim() || undefined;
+      const { challenge_id, options } = await localWebauthnRegisterStart(
+        requestedUsername,
+      );
+      const credential = await beginRegistration(options as never);
+      await localWebauthnRegisterFinish(challenge_id, credential);
+      setUsername(requestedUsername || 'local-admin');
+      setNotice(
+        'Windows Hello registered. You can now log in with Windows Hello.',
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Windows Hello registration failed. Please try again.',
+      );
+    } finally {
+      setRegistering(false);
     }
   };
 
@@ -107,7 +138,7 @@ export default function Login() {
             {/* WebAuthn Login */}
             <button
               onClick={handleWebAuthnLogin}
-              disabled={loading}
+              disabled={loading || registering}
               className="w-full px-4 py-2.5 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
             >
               {loading ? (
@@ -120,9 +151,30 @@ export default function Login() {
               )}
             </button>
 
+            <button
+              onClick={handleLocalRegistration}
+              disabled={loading || registering}
+              className="w-full px-4 py-2.5 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:cursor-not-allowed text-gray-100 font-medium rounded-lg transition-colors border border-gray-600"
+            >
+              {registering
+                ? 'Registering Windows Hello...'
+                : 'Register Windows Hello for local admin'}
+            </button>
+
+            <p className="text-xs text-gray-500 -mt-2">
+              Local development only. Leave username blank to register the
+              bootstrapped local admin account.
+            </p>
+
             {error && (
               <div className="p-3 bg-red-900/30 border border-red-800 rounded-lg">
                 <p className="text-red-400 text-sm">{error}</p>
+              </div>
+            )}
+
+            {notice && (
+              <div className="p-3 bg-emerald-900/25 border border-emerald-800 rounded-lg">
+                <p className="text-emerald-300 text-sm">{notice}</p>
               </div>
             )}
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,6 +26,55 @@ export interface Agent {
   capabilities: string[];
   created_at: string;
   updated_at: string;
+  default_provider?: string | null;
+  default_id_model?: string | null;
+  default_ego_model?: string | null;
+}
+
+export type LlmProviderName =
+  | 'openai'
+  | 'anthropic'
+  | 'ollama'
+  | 'grok'
+  | 'gemini';
+
+export interface LlmProvider {
+  provider: LlmProviderName;
+  enabled: boolean;
+  base_url: string | null;
+  approved_models: string[];
+  default_model: string | null;
+  has_api_key: boolean;
+  updated_at: string;
+}
+
+export interface LlmProviderTestResult {
+  ok: boolean;
+  provider: LlmProviderName;
+  model: string;
+  latency_ms: number;
+  preview?: string;
+  error?: string;
+}
+
+export interface UpdateLlmProviderData {
+  enabled: boolean;
+  base_url?: string | null;
+  approved_models?: string[];
+  default_model?: string | null;
+  api_key?: string;
+}
+
+export interface AgentEgressEvent {
+  event_id: string;
+  user_id: string;
+  agent_id: string | null;
+  orion_id: string;
+  event_type: string;
+  payload: unknown;
+  enqueued_at: string;
+  attempts: number;
+  created_at: string;
 }
 
 export interface AgentBirthResponse {
@@ -42,7 +91,10 @@ export interface AgentStatusResponse {
   documents: string[];
   soul_immutable: boolean;
   personality_preview?: string;
-  last_heartbeat?: string;
+  default_provider?: string | null;
+  default_id_model?: string | null;
+  default_ego_model?: string | null;
+  last_heartbeat?: string | null;
 }
 
 export interface OidcProvider {
@@ -76,6 +128,11 @@ export interface SetupStatus {
   bootstrap_mode?: 'installer_required' | 'operational';
   recommended_installer?: {
     command: string;
+    commands?: {
+      powershell?: string;
+      bash?: string;
+      published_image?: string;
+    };
     image_role: string;
   };
 }

--- a/migrations/005_orion_egress_events.sql
+++ b/migrations/005_orion_egress_events.sql
@@ -1,0 +1,17 @@
+-- Durable Orion egress idempotency store.
+
+CREATE TABLE orion_egress_events (
+    event_id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    agent_id UUID,
+    orion_id UUID NOT NULL,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    enqueued_at TIMESTAMPTZ NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_orion_egress_events_user ON orion_egress_events(user_id);
+CREATE INDEX idx_orion_egress_events_agent ON orion_egress_events(agent_id);
+CREATE INDEX idx_orion_egress_events_created ON orion_egress_events(created_at);

--- a/migrations/006_agent_tokens.sql
+++ b/migrations/006_agent_tokens.sql
@@ -1,0 +1,21 @@
+-- Long-lived agent-scoped identity tokens minted at bundle download.
+--
+-- Design: each row's `id` is the JWT `jti` claim. The token itself is a JWT signed with
+-- SAO_JWT_SECRET (HS256), carrying entity claims (principal_type=non_human, human_owner=user_id,
+-- entity_kind=orion, scope, etc.). This row exists primarily for revocation: validation
+-- decodes the JWT, then looks up jti=id and rejects if revoked_at IS NOT NULL or expired.
+-- Future migration to Entra/external IdP swaps the issuance + verification path but keeps the
+-- bundle/runtime contract (Authorization: Bearer <opaque-or-jwt>) intact.
+
+CREATE TABLE agent_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    issued_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    issued_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    scope TEXT NOT NULL DEFAULT 'orion:policy orion:egress llm:generate'
+);
+
+CREATE INDEX idx_agent_tokens_active ON agent_tokens(agent_id) WHERE revoked_at IS NULL;

--- a/migrations/007_llm_provider_settings.sql
+++ b/migrations/007_llm_provider_settings.sql
@@ -1,0 +1,20 @@
+-- Admin-managed LLM provider configuration. API keys themselves live in vault_secrets
+-- under labels 'provider:openai:api_key' and 'provider:anthropic:api_key' so they reuse
+-- the existing AES-GCM-SIV envelope. Ollama needs no key, only a base_url.
+
+CREATE TABLE llm_provider_settings (
+    provider TEXT PRIMARY KEY CHECK (provider IN ('openai', 'anthropic', 'ollama', 'grok', 'gemini')),
+    enabled BOOLEAN NOT NULL DEFAULT false,
+    base_url TEXT,
+    approved_models JSONB NOT NULL DEFAULT '[]'::jsonb,
+    default_model TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by UUID REFERENCES users(id) ON DELETE SET NULL
+);
+
+INSERT INTO llm_provider_settings (provider, enabled) VALUES
+    ('openai', false),
+    ('anthropic', false),
+    ('ollama', false),
+    ('grok', false),
+    ('gemini', false);

--- a/migrations/008_agent_llm_defaults.sql
+++ b/migrations/008_agent_llm_defaults.sql
@@ -1,0 +1,6 @@
+-- Per-entity LLM provider + model selection. Set at agent creation, used by SAO LLM proxy
+-- to dispatch /api/llm/generate calls coming from that agent.
+
+ALTER TABLE agents ADD COLUMN default_provider TEXT;
+ALTER TABLE agents ADD COLUMN default_id_model TEXT;
+ALTER TABLE agents ADD COLUMN default_ego_model TEXT;

--- a/migrations/009_llm_provider_grok_gemini.sql
+++ b/migrations/009_llm_provider_grok_gemini.sql
@@ -1,0 +1,12 @@
+-- Add Grok (xAI) and Gemini (Google Generative Language) to the llm_provider_settings allowlist.
+-- Idempotent for fresh installs that already have the relaxed constraint from 007.
+
+ALTER TABLE llm_provider_settings DROP CONSTRAINT IF EXISTS llm_provider_settings_provider_check;
+ALTER TABLE llm_provider_settings
+    ADD CONSTRAINT llm_provider_settings_provider_check
+    CHECK (provider IN ('openai', 'anthropic', 'ollama', 'grok', 'gemini'));
+
+INSERT INTO llm_provider_settings (provider, enabled) VALUES
+    ('grok', false),
+    ('gemini', false)
+ON CONFLICT (provider) DO NOTHING;

--- a/scripts/local-mvp-smoke.ps1
+++ b/scripts/local-mvp-smoke.ps1
@@ -1,0 +1,145 @@
+param(
+    [switch]$StartCompose,
+    [string]$BaseUrl = "http://localhost:3100",
+    [string]$PostgresPassword = "local-dev-only-change-me",
+    [string]$JwtSecret = "local-dev-only-change-me",
+    [string]$VaultPassphrase = "local-dev-only-change-me",
+    [string]$AdminUsername = "local-admin",
+    # Bundle / LLM-provider checks. Set OllamaBaseUrl to your reachable Ollama; leave blank to skip.
+    [string]$OllamaBaseUrl = "",
+    [string]$OllamaModel = "llama3.2",
+    # Pass -SkipBundle to avoid attempting bundle download when no installer is staged.
+    [switch]$SkipBundle
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Push-Location $repoRoot
+try {
+    $env:POSTGRES_PASSWORD = $PostgresPassword
+    $env:SAO_JWT_SECRET = $JwtSecret
+    $env:SAO_LOCAL_BOOTSTRAP = "true"
+    $env:SAO_LOCAL_VAULT_PASSPHRASE = $VaultPassphrase
+    $env:SAO_LOCAL_ADMIN_USERNAME = $AdminUsername
+
+    if ($StartCompose) {
+        docker compose -f docker/docker-compose.yml up -d --build
+    }
+
+    $deadline = (Get-Date).AddSeconds(90)
+    do {
+        try {
+            Invoke-RestMethod -Uri "$BaseUrl/api/health" -Method Get | Out-Null
+            break
+        }
+        catch {
+            if ((Get-Date) -gt $deadline) {
+                throw "SAO health endpoint did not become ready at $BaseUrl."
+            }
+            Start-Sleep -Seconds 3
+        }
+    } while ($true)
+
+    docker compose -f docker/docker-compose.yml run --rm `
+        -e SAO_LOCAL_BOOTSTRAP=true `
+        -e SAO_LOCAL_VAULT_PASSPHRASE="$VaultPassphrase" `
+        -e SAO_LOCAL_ADMIN_USERNAME="$AdminUsername" `
+        sao sao-server bootstrap-local | Write-Host
+
+    $token = docker compose -f docker/docker-compose.yml run --rm `
+        -e SAO_LOCAL_BOOTSTRAP=true `
+        -e SAO_LOCAL_ADMIN_USERNAME="$AdminUsername" `
+        sao sao-server mint-dev-token | Select-Object -Last 1
+
+    if (-not $token) {
+        throw "Failed to mint local SAO bearer token."
+    }
+
+    $setup = Invoke-RestMethod -Uri "$BaseUrl/api/setup/status" -Method Get
+    if ($setup.bootstrap_mode -ne "operational") {
+        throw "Expected setup bootstrap_mode=operational; got $($setup.bootstrap_mode)."
+    }
+
+    $headers = @{ Authorization = "Bearer $token" }
+    $policy = Invoke-RestMethod -Uri "$BaseUrl/api/orion/policy" -Method Get -Headers $headers
+    if ($policy.source -ne "sao") {
+        throw "Expected SAO policy source; got $($policy.source)."
+    }
+
+    $eventId = [guid]::NewGuid()
+    $orionId = [guid]::NewGuid()
+    $correlationId = [guid]::NewGuid()
+    $body = @{
+        orionId = $orionId
+        events = @(
+            @{
+                id = $eventId
+                enqueuedAt = (Get-Date).ToUniversalTime().ToString("o")
+                attempts = 1
+                event = @{
+                    auditAction = @{
+                        action = "local MVP smoke test"
+                        correlationId = $correlationId
+                    }
+                }
+            }
+        )
+    } | ConvertTo-Json -Depth 8
+
+    $egress = Invoke-RestMethod -Uri "$BaseUrl/api/orion/egress" -Method Post -Headers $headers -ContentType "application/json" -Body $body
+    if ($egress.accepted -lt 1 -and $egress.duplicate -lt 1) {
+        throw "Expected Orion egress ack or duplicate; got $($egress | ConvertTo-Json -Depth 8)."
+    }
+
+    # ---- Optional: configure Ollama provider, create an agent, exercise the bundle endpoint.
+
+    if ($OllamaBaseUrl) {
+        $providerBody = @{
+            enabled         = $true
+            base_url        = $OllamaBaseUrl
+            approved_models = @($OllamaModel)
+            default_model   = $OllamaModel
+        } | ConvertTo-Json -Depth 8
+
+        Invoke-RestMethod -Uri "$BaseUrl/api/admin/llm-providers/ollama" `
+            -Method Put -Headers $headers -ContentType "application/json" -Body $providerBody | Out-Null
+        Write-Host "Configured Ollama provider at $OllamaBaseUrl with model $OllamaModel."
+
+        $agentBody = @{
+            name               = "smoke-orion-$([guid]::NewGuid().ToString().Substring(0,8))"
+            default_provider   = "ollama"
+            default_id_model   = $OllamaModel
+            default_ego_model  = $OllamaModel
+        } | ConvertTo-Json -Depth 8
+        Invoke-RestMethod -Uri "$BaseUrl/api/agents" -Method Post -Headers $headers `
+            -ContentType "application/json" -Body $agentBody | Out-Null
+        $agents = (Invoke-RestMethod -Uri "$BaseUrl/api/agents" -Method Get -Headers $headers).agents
+        $smokeAgent = $agents | Where-Object { $_.name -like 'smoke-orion-*' } | Select-Object -Last 1
+        if (-not $smokeAgent) { throw "Smoke agent was not created." }
+        Write-Host "Created smoke agent $($smokeAgent.id)."
+
+        if (-not $SkipBundle) {
+            $bundleResponse = Invoke-WebRequest -Uri "$BaseUrl/api/agents/$($smokeAgent.id)/bundle" `
+                -Headers $headers -Method Get -ErrorAction SilentlyContinue
+            if ($bundleResponse.StatusCode -eq 200) {
+                $tempZip = Join-Path ([System.IO.Path]::GetTempPath()) "smoke-bundle.zip"
+                [System.IO.File]::WriteAllBytes($tempZip, $bundleResponse.Content)
+                Write-Host "Bundle downloaded ($($bundleResponse.Content.Length) bytes) to $tempZip."
+            }
+            else {
+                Write-Warning "Bundle download returned $($bundleResponse.StatusCode). If 503, set SAO_ORION_INSTALLER_DIR + SAO_ORION_INSTALLER_FILENAME and re-run docker compose up."
+            }
+        }
+    }
+    else {
+        Write-Host "Skipped LLM provider + bundle checks (OllamaBaseUrl not set)."
+    }
+
+    Write-Host "SAO local MVP smoke test passed."
+    Write-Host "SAO_BASE_URL=$BaseUrl"
+    Write-Host "SAO_DEV_BEARER_TOKEN=$token"
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

Stands up the end-to-end loop where a SAO admin configures provider keys, a user creates an OrionII entity in the UI, downloads a self-contained bundle, and the entity phones home and chats — with **every model call proxied through SAO** so upstream keys never leave the server.

- **Entity identity** as OIDC-shaped JWTs (`principal_type=non_human`, `human_owner=<creating user>`, `jti`-backed revocation). Wire-shape is portable to a future Entra/external-IdP swap; only the issuer/verifier has to change, the bundle/runtime contract stays put.
- **LLM proxy** (`POST /api/llm/generate`) dispatches to OpenAI, Anthropic Claude, **xAI Grok**, **Google Gemini**, or **Ollama**. Keys live in the SAO vault, every call is audited, revoking an entity token instantly cuts off model access.
- **Admin /admin/llm-providers** with per-provider catalog metadata (key-format hint, console link, preset model list) and a **Test connection** button that exercises the real upstream call path.
- **User AgentsPage** wizard captures provider + Id/Ego model; **Download bundle** returns a ZIP of `config.json` + `OrionII-Setup.msi`. New **/agents/:id/events** page polls the live egress feed (5s).
- **Bundle delivery via Compose**: `docker-compose.yml` mounts `SAO_ORION_INSTALLER_DIR` read-only at `/installer`; `SAO_ORION_INSTALLER_PATH` points the bundle endpoint at the MSI built by OrionII.
- **Schema**: migrations 006-009 add `agent_tokens`, `llm_provider_settings`, agent LLM-default columns, and the Grok/Gemini constraint relaxation.
- **Docs**: refreshed [runbook](docs/runbooks/local-orion-sao-mvp.md), [orion-sao-mvp contract](docs/orion-sao-mvp.md), READMEs, and `COORDINATION.md` (in OrionII) to match the implementation.

## Why

The control plane existed but had no path for a user to actually instantiate an entity that worked. This PR closes that loop while keeping all upstream credentials inside SAO, so adding/swapping/rotating providers never requires touching an installed entity.

## Reviewer notes

- The OrionII repo (`C:\Repo\OrionII`) has the matching client-side changes — bootstrap config loader, identity adoption from the SAO-assigned `agent_id`, and a `SaoProxyWithFallback` model variant that calls `/api/llm/generate`. That repo's commit is separate.
- `auth/session.rs` was reordered to satisfy `clippy::items_after_test_module` — pre-existing nit that was blocking the workspace gate; behavior unchanged.
- Bundle download revokes any prior tokens for the same agent (one live bundle per agent). Deleting an agent bulk-revokes its tokens.
- `/api/llm/generate` requires an entity-scoped JWT, not a user JWT; that's enforced in `routes/llm.rs::EntityCaller`.
- `OrionBearerUser` in `routes/orion.rs` accepts both entity tokens (preferred) and user JWTs (back-compat with the dev-token flow). Body-supplied `agentId` is ignored when an entity token is present.
- The `frontend/empty-installer-mount/.gitkeep` is a placeholder so Compose validates even before the operator stages an MSI.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 50 SAO tests pass
- [x] `npx tsc --noEmit` + `npm test` — frontend tsc clean, 8 contract tests pass
- [x] `docker compose -f docker/docker-compose.yml config` validates with the new mount
- [ ] **Manual e2e** (requires the OrionII MSI built locally — see runbook):
  1. `npm run tauri build -- --bundles msi` in OrionII
  2. Set `SAO_ORION_INSTALLER_DIR` + `SAO_ORION_INSTALLER_FILENAME` + `SAO_PUBLIC_BASE_URL`, bring up Compose, bootstrap-local
  3. Log in as local-admin, configure Ollama (or any cloud provider with a key), Test connection
  4. Create an agent with provider+model, click Download bundle
  5. Drop `config.json` into `%APPDATA%\OrionII\`, run the MSI, launch OrionII, send a chat
  6. Confirm `/agents/:id/events` shows live egress and the agent badge turns active

🤖 Generated with [Claude Code](https://claude.com/claude-code)