### PR TITLE
feat: birth event + self-serve installer sources + slim bundle anchor

### DIFF
--- a/crates/sao-server/src/db/agents.rs
+++ b/crates/sao-server/src/db/agents.rs
@@ -15,9 +15,32 @@ pub struct AgentRow {
     pub default_provider: Option<String>,
     pub default_id_model: Option<String>,
     pub default_ego_model: Option<String>,
+    pub installer_sha256: Option<String>,
+    pub installer_filename: Option<String>,
+    pub installer_version: Option<String>,
 }
 
-const SELECT_COLS: &str = "owner_user_id, id, name, public_key, state, capabilities, created_at, updated_at, default_provider, default_id_model, default_ego_model";
+const SELECT_COLS: &str = "owner_user_id, id, name, public_key, state, capabilities, created_at, updated_at, default_provider, default_id_model, default_ego_model, installer_sha256, installer_filename, installer_version";
+
+pub async fn set_installer_pin(
+    pool: &PgPool,
+    id: Uuid,
+    sha256: &str,
+    filename: &str,
+    version: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE agents SET installer_sha256 = $2, installer_filename = $3, installer_version = $4, updated_at = now() \
+         WHERE id = $1",
+    )
+    .bind(id)
+    .bind(sha256)
+    .bind(filename)
+    .bind(version)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
 
 pub async fn list_agents(
     pool: &PgPool,

--- a/crates/sao-server/src/db/installer_sources.rs
+++ b/crates/sao-server/src/db/installer_sources.rs
@@ -1,0 +1,123 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[allow(dead_code)] // created_by + get() are read on review-style queries we'll add later
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct InstallerSourceRow {
+    pub id: Uuid,
+    pub kind: String,
+    pub url: String,
+    pub filename: String,
+    pub version: String,
+    pub expected_sha256: String,
+    pub is_default: bool,
+    pub enabled: bool,
+    pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing)]
+    pub created_by: Option<Uuid>,
+}
+
+pub async fn list(pool: &PgPool) -> Result<Vec<InstallerSourceRow>, sqlx::Error> {
+    sqlx::query_as::<_, InstallerSourceRow>(
+        "SELECT id, kind, url, filename, version, expected_sha256, is_default, enabled, created_at, created_by \
+         FROM installer_sources ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+#[allow(dead_code)]
+pub async fn get(pool: &PgPool, id: Uuid) -> Result<Option<InstallerSourceRow>, sqlx::Error> {
+    sqlx::query_as::<_, InstallerSourceRow>(
+        "SELECT id, kind, url, filename, version, expected_sha256, is_default, enabled, created_at, created_by \
+         FROM installer_sources WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+}
+
+pub async fn get_default(
+    pool: &PgPool,
+    kind: &str,
+) -> Result<Option<InstallerSourceRow>, sqlx::Error> {
+    sqlx::query_as::<_, InstallerSourceRow>(
+        "SELECT id, kind, url, filename, version, expected_sha256, is_default, enabled, created_at, created_by \
+         FROM installer_sources WHERE kind = $1 AND is_default = true AND enabled = true",
+    )
+    .bind(kind)
+    .fetch_optional(pool)
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn insert(
+    pool: &PgPool,
+    kind: &str,
+    url: &str,
+    filename: &str,
+    version: &str,
+    expected_sha256: &str,
+    is_default: bool,
+    created_by: Uuid,
+) -> Result<InstallerSourceRow, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    if is_default {
+        sqlx::query("UPDATE installer_sources SET is_default = false WHERE kind = $1")
+            .bind(kind)
+            .execute(&mut *tx)
+            .await?;
+    }
+    let row = sqlx::query_as::<_, InstallerSourceRow>(
+        "INSERT INTO installer_sources (kind, url, filename, version, expected_sha256, is_default, created_by) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) \
+         RETURNING id, kind, url, filename, version, expected_sha256, is_default, enabled, created_at, created_by",
+    )
+    .bind(kind)
+    .bind(url)
+    .bind(filename)
+    .bind(version)
+    .bind(expected_sha256)
+    .bind(is_default)
+    .bind(created_by)
+    .fetch_one(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(row)
+}
+
+pub async fn set_default(
+    pool: &PgPool,
+    id: Uuid,
+) -> Result<Option<InstallerSourceRow>, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let kind: Option<(String,)> = sqlx::query_as("SELECT kind FROM installer_sources WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await?;
+    let Some((kind,)) = kind else {
+        return Ok(None);
+    };
+    sqlx::query("UPDATE installer_sources SET is_default = false WHERE kind = $1")
+        .bind(&kind)
+        .execute(&mut *tx)
+        .await?;
+    let row = sqlx::query_as::<_, InstallerSourceRow>(
+        "UPDATE installer_sources SET is_default = true WHERE id = $1 \
+         RETURNING id, kind, url, filename, version, expected_sha256, is_default, enabled, created_at, created_by",
+    )
+    .bind(id)
+    .fetch_one(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(Some(row))
+}
+
+pub async fn delete(pool: &PgPool, id: Uuid) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM installer_sources WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}

--- a/crates/sao-server/src/db/mod.rs
+++ b/crates/sao-server/src/db/mod.rs
@@ -3,6 +3,7 @@ pub mod admin_entity;
 pub mod agent_tokens;
 pub mod agents;
 pub mod audit;
+pub mod installer_sources;
 pub mod llm_providers;
 pub mod migrate;
 pub mod oidc;

--- a/crates/sao-server/src/installers.rs
+++ b/crates/sao-server/src/installers.rs
@@ -1,0 +1,149 @@
+//! Installer fetch + sha256-verified cache.
+//!
+//! Layout under SAO_DATA_DIR:
+//!   installers/<sha256>/<filename>     -- the verified artifact
+//!   installers/<sha256>/.url           -- the source URL for traceability
+//!
+//! Pinning a sha to a path means we can serve old agents the exact MSI they were created with
+//! while the default rolls forward.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+
+use crate::db::installer_sources::InstallerSourceRow;
+
+#[allow(dead_code)] // NotConfigured reserved for callers that don't pre-check the DB
+#[derive(Debug, Error)]
+pub enum InstallerError {
+    #[error("installer source not configured")]
+    NotConfigured,
+    #[error("installer download failed: {0}")]
+    Http(String),
+    #[error("installer hash mismatch (expected {expected}, got {actual})")]
+    HashMismatch { expected: String, actual: String },
+    #[error("installer io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Returns the local path to the cached installer for `source`, downloading if absent.
+/// On success the file at the returned path is byte-for-byte the upstream artifact and its
+/// sha256 matches `source.expected_sha256`.
+pub async fn fetch_or_cache(source: &InstallerSourceRow) -> Result<PathBuf, InstallerError> {
+    let cache_dir = installers_root().join(&source.expected_sha256);
+    let target = cache_dir.join(&source.filename);
+
+    if target.exists() {
+        // Re-verify on every serve — cheap insurance against bit-rot or substitution.
+        let actual = sha256_of_file(&target).await?;
+        if actual.eq_ignore_ascii_case(&source.expected_sha256) {
+            return Ok(target);
+        }
+        tracing::warn!(
+            path = %target.display(),
+            "Cached installer hash mismatch — refetching"
+        );
+        let _ = tokio::fs::remove_file(&target).await;
+    }
+
+    tokio::fs::create_dir_all(&cache_dir).await?;
+
+    tracing::info!(url = %source.url, "Downloading OrionII installer");
+    let resp = reqwest::Client::builder()
+        .build()
+        .map_err(|e| InstallerError::Http(e.to_string()))?
+        .get(&source.url)
+        .send()
+        .await
+        .map_err(|e| InstallerError::Http(e.to_string()))?;
+
+    if !resp.status().is_success() {
+        return Err(InstallerError::Http(format!(
+            "GET {} returned {}",
+            source.url,
+            resp.status()
+        )));
+    }
+
+    let body = resp
+        .bytes()
+        .await
+        .map_err(|e| InstallerError::Http(e.to_string()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&body);
+    let mut tmp = tokio::fs::File::create(&target).await?;
+    tmp.write_all(&body).await?;
+    tmp.flush().await?;
+    drop(tmp);
+
+    let actual = format!("{:x}", hasher.finalize());
+    if !actual.eq_ignore_ascii_case(&source.expected_sha256) {
+        let _ = tokio::fs::remove_file(&target).await;
+        return Err(InstallerError::HashMismatch {
+            expected: source.expected_sha256.clone(),
+            actual,
+        });
+    }
+
+    let url_marker = cache_dir.join(".url");
+    let _ = tokio::fs::write(&url_marker, &source.url).await;
+
+    Ok(target)
+}
+
+/// Locate a previously cached installer by its sha256 (used when serving a pinned bundle).
+pub fn cached_path(sha256: &str, filename: &str) -> Option<PathBuf> {
+    let p = installers_root().join(sha256).join(filename);
+    if p.exists() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Compute sha256 of a file you intend to register as a source. Useful for the admin flow:
+/// admin uploads or points at a URL, server confirms the sha matches what they expect.
+pub async fn sha256_of_url(url: &str) -> Result<String, InstallerError> {
+    let resp = reqwest::Client::new()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| InstallerError::Http(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(InstallerError::Http(format!(
+            "GET {url} returned {}",
+            resp.status()
+        )));
+    }
+    let body = resp
+        .bytes()
+        .await
+        .map_err(|e| InstallerError::Http(e.to_string()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&body);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+async fn sha256_of_file(path: &Path) -> std::io::Result<String> {
+    use tokio::io::AsyncReadExt;
+    let mut f = tokio::fs::File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = f.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn installers_root() -> PathBuf {
+    let base = std::env::var_os("SAO_DATA_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/data/sao"));
+    base.join("installers")
+}

--- a/crates/sao-server/src/main.rs
+++ b/crates/sao-server/src/main.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod db;
+mod installers;
 mod llm;
 mod routes;
 mod security;

--- a/crates/sao-server/src/routes/admin.rs
+++ b/crates/sao-server/src/routes/admin.rs
@@ -40,6 +40,21 @@ pub fn routes() -> Router<AppState> {
             "/api/admin/llm-providers/:provider/test",
             post(test_llm_provider),
         )
+        // OrionII installer source registry (admin only)
+        .route("/api/admin/installer-sources", get(list_installer_sources))
+        .route("/api/admin/installer-sources", post(create_installer_source))
+        .route(
+            "/api/admin/installer-sources/probe",
+            post(probe_installer_source),
+        )
+        .route(
+            "/api/admin/installer-sources/:id",
+            delete(delete_installer_source),
+        )
+        .route(
+            "/api/admin/installer-sources/:id/set-default",
+            post(set_default_installer_source),
+        )
 }
 
 const SUPPORTED_PROVIDERS: &[&str] =
@@ -752,6 +767,212 @@ async fn test_llm_provider(
                 "latency_ms": latency_ms,
                 "error": e.to_string(),
             })),
+        ),
+    }
+}
+
+// --- OrionII installer source registry ---
+
+async fn list_installer_sources(
+    AdminUser(_admin): AdminUser,
+    State(state): State<AppState>,
+) -> (StatusCode, Json<Value>) {
+    match crate::db::installer_sources::list(&state.inner.db).await {
+        Ok(rows) => (StatusCode::OK, Json(json!({ "sources": rows }))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+#[derive(Deserialize)]
+struct ProbeInstallerRequest {
+    url: String,
+}
+
+/// Compute the sha256 of an upstream URL without persisting anything. Lets the admin
+/// confirm the hash before they commit it as `expected_sha256`.
+async fn probe_installer_source(
+    AdminUser(_admin): AdminUser,
+    Json(req): Json<ProbeInstallerRequest>,
+) -> (StatusCode, Json<Value>) {
+    if req.url.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "url is required" })),
+        );
+    }
+    match crate::installers::sha256_of_url(req.url.trim()).await {
+        Ok(sha) => (
+            StatusCode::OK,
+            Json(json!({ "url": req.url, "sha256": sha })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+#[derive(Deserialize)]
+struct CreateInstallerRequest {
+    #[serde(default = "default_kind")]
+    kind: String,
+    url: String,
+    filename: String,
+    version: String,
+    expected_sha256: String,
+    #[serde(default)]
+    is_default: bool,
+}
+
+fn default_kind() -> String {
+    "orion-msi".to_string()
+}
+
+async fn create_installer_source(
+    AdminUser(admin): AdminUser,
+    State(state): State<AppState>,
+    Json(req): Json<CreateInstallerRequest>,
+) -> (StatusCode, Json<Value>) {
+    if req.kind != "orion-msi" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Only kind=orion-msi is supported today" })),
+        );
+    }
+    for (name, value) in [
+        ("url", &req.url),
+        ("filename", &req.filename),
+        ("version", &req.version),
+        ("expected_sha256", &req.expected_sha256),
+    ] {
+        if value.trim().is_empty() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("{name} is required") })),
+            );
+        }
+    }
+    if req.expected_sha256.trim().len() != 64
+        || !req.expected_sha256.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "expected_sha256 must be a 64-char hex digest" })),
+        );
+    }
+
+    let row = match crate::db::installer_sources::insert(
+        &state.inner.db,
+        &req.kind,
+        req.url.trim(),
+        req.filename.trim(),
+        req.version.trim(),
+        &req.expected_sha256.trim().to_lowercase(),
+        req.is_default,
+        admin.user_id,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    // Pre-warm the cache so the next bundle download is instant. Failure here is non-fatal.
+    let pre_warm = match crate::installers::fetch_or_cache(&row).await {
+        Ok(path) => json!({ "ok": true, "cache_path": path.display().to_string() }),
+        Err(e) => json!({ "ok": false, "error": e.to_string() }),
+    };
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(admin.user_id),
+        None,
+        "admin.installer_sources.create",
+        Some("installer_source"),
+        Some(json!({
+            "id": row.id,
+            "kind": row.kind,
+            "version": row.version,
+            "is_default": row.is_default,
+            "pre_warm": pre_warm,
+        })),
+        None,
+        None,
+    )
+    .await;
+
+    (
+        StatusCode::CREATED,
+        Json(json!({ "source": row, "pre_warm": pre_warm })),
+    )
+}
+
+async fn delete_installer_source(
+    AdminUser(admin): AdminUser,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> (StatusCode, Json<Value>) {
+    match crate::db::installer_sources::delete(&state.inner.db, id).await {
+        Ok(true) => {
+            let _ = crate::db::audit::insert_audit_log(
+                &state.inner.db,
+                Some(admin.user_id),
+                None,
+                "admin.installer_sources.delete",
+                Some("installer_source"),
+                Some(json!({ "id": id })),
+                None,
+                None,
+            )
+            .await;
+            (StatusCode::OK, Json(json!({ "deleted": true })))
+        }
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Installer source not found" })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+async fn set_default_installer_source(
+    AdminUser(admin): AdminUser,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> (StatusCode, Json<Value>) {
+    match crate::db::installer_sources::set_default(&state.inner.db, id).await {
+        Ok(Some(row)) => {
+            let _ = crate::db::audit::insert_audit_log(
+                &state.inner.db,
+                Some(admin.user_id),
+                None,
+                "admin.installer_sources.set_default",
+                Some("installer_source"),
+                Some(json!({ "id": row.id, "kind": row.kind, "version": row.version })),
+                None,
+                None,
+            )
+            .await;
+            (StatusCode::OK, Json(json!({ "source": row })))
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Installer source not found" })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
         ),
     }
 }

--- a/crates/sao-server/src/routes/agents.rs
+++ b/crates/sao-server/src/routes/agents.rs
@@ -101,7 +101,7 @@ async fn create_agent(
         );
     }
 
-    match crate::db::agents::create_agent(
+    let created = match crate::db::agents::create_agent(
         &state.inner.db,
         user.user_id,
         name,
@@ -111,49 +111,83 @@ async fn create_agent(
     )
     .await
     {
-        Ok(_agent) => {
-            let _ = crate::db::audit::insert_audit_log(
-                &state.inner.db,
-                Some(user.user_id),
-                None,
-                "agents.create",
-                Some("agent"),
-                Some(json!({
-                    "name": name,
-                    "identity_agent_id": identity_agent_id,
-                    "documents": ["soul.md", "ethics.md", "org-map.md", "personality.md"],
-                    "request_id": context.request_id,
-                })),
-                context.client_ip.as_deref(),
-                context.user_agent.as_deref(),
-            )
-            .await;
-            crate::db::audit::log_birth_event(&identity_agent_id);
-            let ethic_preview =
-                sao_core::ethical_bridge::get_triangleethic_preview(&identity_agent_id);
-            (
-                StatusCode::CREATED,
-                Json(json!({
-                    "status": "READY",
-                    "documents": ["soul.md", "ethics.md", "org-map.md", "personality.md"],
-                    "soul_immutable": true,
-                    "personality_preview": "default ego traits loaded - Superego will evolve this later",
-                    "triangleethic_preview": ethic_preview,
-                })),
-            )
-        }
+        Ok(agent) => agent,
         Err(e) => {
             let _ = state
                 .inner
                 .identity_manager
                 .remove_agent(&identity_agent_id);
             let _ = std::fs::remove_dir_all(&agent_dir);
-            (
+            return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({ "error": e.to_string() })),
-            )
+            );
+        }
+    };
+
+    // Pull-on-create: if a default OrionII installer source is configured, fetch it
+    // (cached by sha) and pin those coordinates to this agent. Bundle download serves the
+    // pinned copy, so re-rolling the default later doesn't break old agents.
+    let mut installer_status = serde_json::Value::Null;
+    if let Ok(Some(source)) =
+        crate::db::installer_sources::get_default(&state.inner.db, "orion-msi").await
+    {
+        match crate::installers::fetch_or_cache(&source).await {
+            Ok(_path) => {
+                let _ = crate::db::agents::set_installer_pin(
+                    &state.inner.db,
+                    created.id,
+                    &source.expected_sha256,
+                    &source.filename,
+                    &source.version,
+                )
+                .await;
+                installer_status = json!({
+                    "pinned": true,
+                    "version": source.version,
+                    "sha256": source.expected_sha256,
+                    "filename": source.filename,
+                });
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, agent_id = %created.id, "Failed to pin installer for new agent");
+                installer_status = json!({ "pinned": false, "error": e.to_string() });
+            }
         }
     }
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(user.user_id),
+        None,
+        "agents.create",
+        Some("agent"),
+        Some(json!({
+            "name": name,
+            "identity_agent_id": identity_agent_id,
+            "documents": ["soul.md", "ethics.md", "org-map.md", "personality.md"],
+            "installer": installer_status,
+            "request_id": context.request_id,
+        })),
+        context.client_ip.as_deref(),
+        context.user_agent.as_deref(),
+    )
+    .await;
+    crate::db::audit::log_birth_event(&identity_agent_id);
+    let ethic_preview =
+        sao_core::ethical_bridge::get_triangleethic_preview(&identity_agent_id);
+    (
+        StatusCode::CREATED,
+        Json(json!({
+            "status": "READY",
+            "agent_id": created.id,
+            "documents": ["soul.md", "ethics.md", "org-map.md", "personality.md"],
+            "soul_immutable": true,
+            "personality_preview": "default ego traits loaded - Superego will evolve this later",
+            "triangleethic_preview": ethic_preview,
+            "installer": installer_status,
+        })),
+    )
 }
 
 async fn get_agent_status(

--- a/crates/sao-server/src/routes/bundle.rs
+++ b/crates/sao-server/src/routes/bundle.rs
@@ -1,6 +1,13 @@
 //! GET /api/agents/:id/bundle — packages a config.json + Tauri MSI installer for the user to
-//! run on their workstation. The config.json carries the entity's identity token and chosen
-//! LLM defaults. The MSI is read from `SAO_ORION_INSTALLER_PATH`.
+//! run on their workstation. The config.json carries the entity's identity token and the
+//! anchor SAO URL. The MSI is read from one of three sources, in order:
+//!
+//!   1. The agent's pinned installer in the local cache
+//!      (`SAO_DATA_DIR/installers/<sha>/<filename>`). If the cache file is missing, SAO
+//!      re-fetches from the original `installer_sources` row by sha lookup.
+//!   2. A freshly-pinned default installer source (covers the case where an agent was
+//!      created before any installer source was registered).
+//!   3. `SAO_ORION_INSTALLER_PATH` env var — the legacy mount-based fallback.
 
 use std::io::{Cursor, Write};
 
@@ -20,6 +27,7 @@ use zip::CompressionMethod;
 
 use crate::auth::agent_tokens;
 use crate::auth::middleware::AuthUser;
+use crate::db::agents::AgentRow;
 use crate::security::RequestAuditContext;
 use crate::state::AppState;
 
@@ -31,7 +39,7 @@ const README_TEXT: &str = "OrionII entity bundle\n\
 =====================\n\
 \n\
 This ZIP contains:\n\
-  config.json            -- Identity token + LLM provider defaults for this entity.\n\
+  config.json            -- SAO base URL + entity identity token (the anchor).\n\
   OrionII-Setup.msi      -- Tauri installer (Windows).\n\
   README-FIRST-RUN.txt   -- this file.\n\
 \n\
@@ -41,12 +49,22 @@ First run\n\
 2. Drop config.json into:\n\
        %APPDATA%\\OrionII\\config.json\n\
    (the installer also accepts it co-located with OrionII.exe).\n\
-3. Launch OrionII. It will adopt the agent_id from config and phone home to SAO.\n\
+3. Launch OrionII. The app will:\n\
+     a. Read the SAO URL + entity token from config.json.\n\
+     b. Call GET {sao_base_url}/api/orion/birth to dynamically receive the\n\
+        live agent metadata, default provider/model, scopes, current policy,\n\
+        and personality seed in a single response.\n\
+     c. Adopt the SAO-assigned identity and start chatting.\n\
+\n\
+Because the runtime config is fetched live, changes the admin makes in SAO\n\
+(switching provider, swapping default model, updating policy) take effect on\n\
+the next OrionII launch -- no re-bundling required.\n\
 \n\
 Security\n\
 --------\n\
-The agent_token is a long-lived bearer credential. Treat config.json like an API key:\n\
-do not share, do not commit. If lost, delete the agent in SAO and download a new bundle.\n";
+The agent_token is a long-lived bearer credential. Treat config.json like an\n\
+API key: do not share, do not commit. If lost, delete the agent in SAO and\n\
+download a new bundle (downloading also revokes any prior tokens for the agent).\n";
 
 async fn download_bundle(
     user: AuthUser,
@@ -89,23 +107,18 @@ async fn download_bundle(
         ));
     }
 
-    let installer_path = std::env::var("SAO_ORION_INSTALLER_PATH").map_err(|_| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({
-                "error": "OrionII installer is not staged on this SAO instance",
-                "hint": "Set SAO_ORION_INSTALLER_PATH to a built .msi (run npm run tauri build in OrionII)",
-            })),
-        )
-    })?;
-    let installer_bytes = tokio::fs::read(&installer_path).await.map_err(|e| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({
-                "error": format!("Failed to read installer at {installer_path}: {e}"),
-            })),
-        )
-    })?;
+    let installer_bytes = match resolve_installer(&state, &agent).await {
+        Ok(bytes) => bytes,
+        Err(message) => {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({
+                    "error": message,
+                    "hint": "Register an OrionII installer source under /admin/installer-sources, or set SAO_ORION_INSTALLER_PATH for the legacy mount-based flow.",
+                })),
+            ));
+        }
+    };
 
     // Revoke any prior tokens for this agent before issuing a new one — one live bundle per agent.
     let revoked = agent_tokens::revoke_for_agent(&state.inner.db, id)
@@ -125,14 +138,24 @@ async fn download_bundle(
     let sao_base_url = std::env::var("SAO_PUBLIC_BASE_URL")
         .unwrap_or_else(|_| "http://localhost:3100".to_string());
 
+    // Anchor-only: sao_base_url + agent_token are the minimum the entity needs to bootstrap.
+    // Everything else (provider, models, policy, scopes, personality) comes from the live
+    // GET /api/orion/birth call OrionII makes on every launch. The provider/model fields are
+    // still embedded as a *fallback* for offline-from-SAO mode and for back-compat with
+    // older clients that don't yet call birth.
     let config = json!({
         "sao_base_url": sao_base_url,
         "agent_id": agent.id,
         "agent_token": minted.jwt,
+        "client_version_min": "0.1.0",
+        "fallback": {
+            "default_provider": provider,
+            "default_id_model": id_model,
+            "default_ego_model": ego_model,
+        },
         "default_provider": provider,
         "default_id_model": id_model,
         "default_ego_model": ego_model,
-        "client_version_min": "0.1.0",
     });
 
     let zip_bytes = build_zip(&config, &installer_bytes).map_err(|e| internal(e.to_string()))?;
@@ -209,4 +232,64 @@ fn bad_request(msg: &str) -> (StatusCode, Json<Value>) {
 
 fn not_found(msg: &str) -> (StatusCode, Json<Value>) {
     (StatusCode::NOT_FOUND, Json(json!({ "error": msg })))
+}
+
+/// Resolve the bytes of the OrionII installer for `agent`, walking the three sources in order.
+async fn resolve_installer(state: &AppState, agent: &AgentRow) -> Result<Vec<u8>, String> {
+    // 1. Pinned source — agent already has installer coordinates.
+    if let (Some(sha), Some(filename)) = (&agent.installer_sha256, &agent.installer_filename) {
+        if let Some(path) = crate::installers::cached_path(sha, filename) {
+            if let Ok(bytes) = tokio::fs::read(&path).await {
+                return Ok(bytes);
+            }
+        }
+        // Cache miss — try to refetch from the installer_sources row that matches this sha.
+        if let Ok(rows) = crate::db::installer_sources::list(&state.inner.db).await {
+            if let Some(source) = rows
+                .into_iter()
+                .find(|r| r.expected_sha256.eq_ignore_ascii_case(sha))
+            {
+                match crate::installers::fetch_or_cache(&source).await {
+                    Ok(path) => {
+                        if let Ok(bytes) = tokio::fs::read(&path).await {
+                            return Ok(bytes);
+                        }
+                    }
+                    Err(e) => return Err(format!("Failed to refetch pinned installer: {e}")),
+                }
+            }
+        }
+    }
+
+    // 2. Fall back to the current default — pin opportunistically so this agent stays stable
+    //    on subsequent downloads even if the default rolls forward.
+    if let Ok(Some(source)) =
+        crate::db::installer_sources::get_default(&state.inner.db, "orion-msi").await
+    {
+        match crate::installers::fetch_or_cache(&source).await {
+            Ok(path) => {
+                let _ = crate::db::agents::set_installer_pin(
+                    &state.inner.db,
+                    agent.id,
+                    &source.expected_sha256,
+                    &source.filename,
+                    &source.version,
+                )
+                .await;
+                if let Ok(bytes) = tokio::fs::read(&path).await {
+                    return Ok(bytes);
+                }
+            }
+            Err(e) => return Err(format!("Failed to fetch default installer: {e}")),
+        }
+    }
+
+    // 3. Legacy env-var fallback (file mounted into the container).
+    if let Ok(path) = std::env::var("SAO_ORION_INSTALLER_PATH") {
+        if let Ok(bytes) = tokio::fs::read(&path).await {
+            return Ok(bytes);
+        }
+    }
+
+    Err("OrionII installer is not available. Register an installer source under /admin/installer-sources.".to_string())
 }

--- a/crates/sao-server/src/routes/orion.rs
+++ b/crates/sao-server/src/routes/orion.rs
@@ -19,6 +19,7 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/orion/policy", get(get_policy))
         .route("/api/orion/egress", post(post_egress))
+        .route("/api/orion/birth", get(get_birth))
 }
 
 /// Authenticated principal calling /api/orion/* — either a downloaded entity (preferred) or a
@@ -124,7 +125,11 @@ pub struct OrionPolicyResponse {
 }
 
 async fn get_policy(_user: OrionBearerUser) -> Json<OrionPolicyResponse> {
-    Json(OrionPolicyResponse {
+    Json(orion_policy())
+}
+
+fn orion_policy() -> OrionPolicyResponse {
+    OrionPolicyResponse {
         version: 1,
         source: "sao",
         rules: vec![
@@ -132,7 +137,155 @@ async fn get_policy(_user: OrionBearerUser) -> Json<OrionPolicyResponse> {
             "Preserve correlation IDs on audit events.",
         ],
         updated_at: Utc::now(),
-    })
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BirthAgent {
+    id: Uuid,
+    name: String,
+    created_at: DateTime<Utc>,
+    default_provider: Option<String>,
+    default_id_model: Option<String>,
+    default_ego_model: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BirthEndpoints {
+    sao_base_url: String,
+    policy_url: &'static str,
+    egress_url: &'static str,
+    llm_url: &'static str,
+    birth_url: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BirthOwner {
+    user_id: Uuid,
+    username: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BirthPersonalitySeed {
+    name: String,
+    stance: String,
+    drives: Vec<String>,
+    deontological: f32,
+    virtue: f32,
+    consequential: f32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrionBirthResponse {
+    birthed_at: DateTime<Utc>,
+    client_version_min: &'static str,
+    agent: BirthAgent,
+    endpoints: BirthEndpoints,
+    owner: BirthOwner,
+    scopes: Vec<&'static str>,
+    policy: OrionPolicyResponse,
+    personality_seed: BirthPersonalitySeed,
+}
+
+const ORION_CLIENT_VERSION_MIN: &str = "0.1.0";
+
+async fn get_birth(
+    user: OrionBearerUser,
+    State(state): State<AppState>,
+    axum::extract::Extension(context): axum::extract::Extension<RequestAuditContext>,
+) -> Result<Json<OrionBirthResponse>, (StatusCode, Json<Value>)> {
+    let agent_id = user.entity_agent_id().ok_or_else(|| {
+        (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": "Birth requires an entity-scoped bearer token (download a fresh bundle).",
+            })),
+        )
+    })?;
+
+    let agent = crate::db::agents::get_agent(&state.inner.db, agent_id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Agent not found" })),
+            )
+        })?;
+
+    let owner_user_id = user.attribution_user();
+    let username = match crate::db::users::get_user_by_id(&state.inner.db, owner_user_id).await {
+        Ok(Some(u)) => Some(u.username),
+        _ => None,
+    };
+
+    let sao_base_url = std::env::var("SAO_PUBLIC_BASE_URL")
+        .unwrap_or_else(|_| "http://localhost:3100".to_string());
+
+    let response = OrionBirthResponse {
+        birthed_at: Utc::now(),
+        client_version_min: ORION_CLIENT_VERSION_MIN,
+        agent: BirthAgent {
+            id: agent.id,
+            name: agent.name.clone(),
+            created_at: agent.created_at,
+            default_provider: agent.default_provider.clone(),
+            default_id_model: agent.default_id_model.clone(),
+            default_ego_model: agent.default_ego_model.clone(),
+        },
+        endpoints: BirthEndpoints {
+            sao_base_url,
+            policy_url: "/api/orion/policy",
+            egress_url: "/api/orion/egress",
+            llm_url: "/api/llm/generate",
+            birth_url: "/api/orion/birth",
+        },
+        owner: BirthOwner {
+            user_id: owner_user_id,
+            username,
+        },
+        scopes: vec!["orion:policy", "orion:egress", "llm:generate"],
+        policy: orion_policy(),
+        personality_seed: BirthPersonalitySeed {
+            name: agent.name,
+            stance: "calm, direct, worker-owned companion".to_string(),
+            drives: vec![
+                "preserve continuity of self".to_string(),
+                "serve the worker locally first".to_string(),
+                "remain accountable to SAO asynchronously".to_string(),
+            ],
+            deontological: 0.34,
+            virtue: 0.33,
+            consequential: 0.33,
+        },
+    };
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(owner_user_id),
+        Some(agent_id),
+        "orion.birth",
+        Some("orion"),
+        Some(json!({
+            "agent_id": agent_id,
+            "request_id": context.request_id,
+        })),
+        context.client_ip.as_deref(),
+        context.user_agent.as_deref(),
+    )
+    .await;
+
+    Ok(Json(response))
 }
 
 #[derive(Debug, Deserialize)]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,13 +27,16 @@ services:
       SAO_OIDC_SCOPES: ${SAO_OIDC_SCOPES:-openid profile email}
       # Used by /api/agents/:id/bundle to embed the right SAO URL in the entity config.json.
       SAO_PUBLIC_BASE_URL: ${SAO_PUBLIC_BASE_URL:-http://localhost:3100}
-      # Path *inside the container* to the OrionII installer; only meaningful when the
-      # installer directory is mounted via SAO_ORION_INSTALLER_DIR (see volumes below).
+      # Optional legacy path: explicit MSI path inside the container, only used when no
+      # installer source is registered under /admin/installer-sources. Newer setups should
+      # register a source instead — SAO will download + sha-verify + cache automatically.
       SAO_ORION_INSTALLER_PATH: ${SAO_ORION_INSTALLER_PATH:-/installer/${SAO_ORION_INSTALLER_FILENAME:-OrionII_0.1.0_x64_en-US.msi}}
     volumes:
+      # `sao-data` holds: jwt_secret.bin, installer cache (installers/<sha>/<filename>),
+      # and any other durable runtime state.
       - sao-data:/data/sao
-      # Mount the host directory containing the OrionII MSI so the bundle endpoint can read it.
-      # Set SAO_ORION_INSTALLER_DIR to the absolute host path (e.g., the bundle/msi output dir).
+      # Optional: mount a host directory containing the OrionII MSI when running in the
+      # legacy env-var flow. Self-serve installer sources don't need this.
       - ${SAO_ORION_INSTALLER_DIR:-./empty-installer-mount}:/installer:ro
     depends_on:
       db:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import AuditLogPage from './pages/AuditLogPage';
 import SkillsCatalogPage from './pages/SkillsCatalogPage';
 import AdminSkillReviewPage from './pages/AdminSkillReviewPage';
 import AdminLlmProvidersPage from './pages/AdminLlmProvidersPage';
+import AdminInstallerSourcesPage from './pages/AdminInstallerSourcesPage';
 import AgentEventsPage from './pages/AgentEventsPage';
 
 function AppRoutes() {
@@ -95,6 +96,14 @@ function AppRoutes() {
           element={
             <ProtectedRoute admin>
               <AdminLlmProvidersPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/admin/installer-sources"
+          element={
+            <ProtectedRoute admin>
+              <AdminInstallerSourcesPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/installer-sources.ts
+++ b/frontend/src/api/installer-sources.ts
@@ -1,0 +1,50 @@
+import { apiRequest } from './client';
+import type {
+  CreateInstallerSourceData,
+  InstallerSource,
+  ProbeInstallerResult,
+} from '../types';
+
+export async function listInstallerSources(): Promise<InstallerSource[]> {
+  const response = await apiRequest<{ sources: InstallerSource[] }>(
+    '/api/admin/installer-sources',
+  );
+  return response.sources;
+}
+
+export async function probeInstallerSource(
+  url: string,
+): Promise<ProbeInstallerResult> {
+  return apiRequest<ProbeInstallerResult>(
+    '/api/admin/installer-sources/probe',
+    {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    },
+  );
+}
+
+export async function createInstallerSource(
+  data: CreateInstallerSourceData,
+): Promise<{ source: InstallerSource; pre_warm: { ok: boolean; cache_path?: string; error?: string } }> {
+  return apiRequest('/api/admin/installer-sources', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function setDefaultInstallerSource(
+  id: string,
+): Promise<InstallerSource> {
+  const response = await apiRequest<{ source: InstallerSource }>(
+    `/api/admin/installer-sources/${id}/set-default`,
+    { method: 'POST' },
+  );
+  return response.source;
+}
+
+export async function deleteInstallerSource(id: string): Promise<void> {
+  await apiRequest<void>(`/api/admin/installer-sources/${id}`, {
+    method: 'DELETE',
+  });
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -69,6 +69,7 @@ export default function Layout() {
               <SidebarLink to="/admin/sso" label="SSO" icon="[S]" />
               <SidebarLink to="/admin/skills/review" label="Skill Reviews" icon="[R]" />
               <SidebarLink to="/admin/llm-providers" label="LLM Providers" icon="[M]" />
+              <SidebarLink to="/admin/installer-sources" label="Installer Sources" icon="[I]" />
             </>
           )}
         </nav>

--- a/frontend/src/pages/AdminInstallerSourcesPage.tsx
+++ b/frontend/src/pages/AdminInstallerSourcesPage.tsx
@@ -1,0 +1,289 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createInstallerSource,
+  deleteInstallerSource,
+  listInstallerSources,
+  probeInstallerSource,
+  setDefaultInstallerSource,
+} from '../api/installer-sources';
+import type { InstallerSource } from '../types';
+
+export default function AdminInstallerSourcesPage() {
+  const queryClient = useQueryClient();
+  const { data: sources, isLoading } = useQuery({
+    queryKey: ['installer-sources'],
+    queryFn: listInstallerSources,
+  });
+
+  const [showCreate, setShowCreate] = useState(false);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-2xl font-bold text-white">OrionII Installer Sources</h1>
+        <button
+          onClick={() => setShowCreate((v) => !v)}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-lg"
+        >
+          {showCreate ? 'Cancel' : '+ Register installer source'}
+        </button>
+      </div>
+      <p className="text-sm text-gray-400 mb-6 max-w-3xl">
+        SAO downloads each registered MSI on first reference, verifies its sha256, and caches
+        it under <span className="font-mono">{`SAO_DATA_DIR/installers/<sha>/`}</span>. When a
+        user creates an entity, SAO pins the current default source's coordinates onto that
+        agent so re-downloading the bundle yields a byte-identical MSI even after the default
+        rolls forward. The convention is to point the default at GitHub Releases'{' '}
+        <span className="font-mono">/releases/latest/download/&lt;asset&gt;</span> URL — that
+        way "make latest the default" is a one-click action whenever a new OrionII release
+        ships.
+      </p>
+
+      {showCreate && (
+        <CreateForm
+          onCreated={async () => {
+            setShowCreate(false);
+            await queryClient.invalidateQueries({ queryKey: ['installer-sources'] });
+          }}
+        />
+      )}
+
+      {isLoading ? (
+        <div className="text-gray-400">Loading...</div>
+      ) : (sources ?? []).length === 0 ? (
+        <div className="text-center py-16 text-gray-500">
+          No installer sources registered yet. Add one to enable self-serve bundle downloads.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {(sources ?? []).map((s) => (
+            <SourceCard
+              key={s.id}
+              source={s}
+              onChanged={async () => {
+                await queryClient.invalidateQueries({ queryKey: ['installer-sources'] });
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Convention: the default installer source points at the latest tagged release in the
+// jbcupps/OrionII GitHub repo. Admins can override the URL to pin a specific tag or
+// switch to an internal mirror.
+const DEFAULT_RELEASE_URL =
+  'https://github.com/jbcupps/OrionII/releases/latest/download/OrionII_0.1.0_x64_en-US.msi';
+
+function CreateForm({ onCreated }: { onCreated: () => Promise<void> | void }) {
+  const [url, setUrl] = useState(DEFAULT_RELEASE_URL);
+  const [filename, setFilename] = useState('OrionII_0.1.0_x64_en-US.msi');
+  const [version, setVersion] = useState('latest');
+  const [sha, setSha] = useState('');
+  const [isDefault, setIsDefault] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [probedSha, setProbedSha] = useState<string | null>(null);
+
+  const handleProbe = async () => {
+    setError('');
+    setProbedSha(null);
+    if (!url.trim()) {
+      setError('URL is required');
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await probeInstallerSource(url.trim());
+      setProbedSha(result.sha256);
+      if (!sha.trim()) setSha(result.sha256);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Probe failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    setError('');
+    setBusy(true);
+    try {
+      await createInstallerSource({
+        url: url.trim(),
+        filename: filename.trim(),
+        version: version.trim(),
+        expected_sha256: sha.trim().toLowerCase(),
+        is_default: isDefault,
+      });
+      await onCreated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Create failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="bg-gray-800 rounded-xl border border-gray-700 p-5 mb-6 space-y-3">
+      <h2 className="text-lg font-semibold text-white">Register installer source</h2>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">Download URL</label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://github.com/jbcupps/OrionII/releases/download/v0.1.0/OrionII_0.1.0_x64_en-US.msi"
+            className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono text-xs"
+          />
+          <button
+            onClick={handleProbe}
+            disabled={busy}
+            className="px-3 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 text-white text-sm rounded-lg"
+          >
+            Probe sha256
+          </button>
+        </div>
+        {probedSha && (
+          <p className="text-xs text-green-400 mt-1 font-mono break-all">
+            Computed: {probedSha}
+          </p>
+        )}
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Filename (in bundle)</label>
+          <input
+            type="text"
+            value={filename}
+            onChange={(e) => setFilename(e.target.value)}
+            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white font-mono text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Version label</label>
+          <input
+            type="text"
+            value={version}
+            onChange={(e) => setVersion(e.target.value)}
+            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white font-mono text-sm"
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">Expected sha256 (64 hex)</label>
+        <input
+          type="text"
+          value={sha}
+          onChange={(e) => setSha(e.target.value)}
+          placeholder="probe above to autofill, or paste a known-good digest"
+          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white font-mono text-xs"
+        />
+      </div>
+      <label className="flex items-center gap-2 text-sm text-gray-300">
+        <input
+          type="checkbox"
+          checked={isDefault}
+          onChange={(e) => setIsDefault(e.target.checked)}
+        />
+        Make this the default — new agents will pin to it.
+      </label>
+      {error && (
+        <div className="rounded border border-red-800 bg-red-900/30 p-2 text-xs text-red-300">
+          {error}
+        </div>
+      )}
+      <div className="flex justify-end">
+        <button
+          onClick={handleCreate}
+          disabled={busy || !url.trim() || !sha.trim()}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-900 text-white text-sm rounded-lg"
+        >
+          {busy ? 'Working...' : 'Register + warm cache'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SourceCard({
+  source,
+  onChanged,
+}: {
+  source: InstallerSource;
+  onChanged: () => Promise<void> | void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSetDefault = async () => {
+    setError('');
+    setBusy(true);
+    try {
+      await setDefaultInstallerSource(source.id);
+      await onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setError('');
+    setBusy(true);
+    try {
+      await deleteInstallerSource(source.id);
+      await onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="bg-gray-800 rounded-xl border border-gray-700 p-5">
+      <div className="flex items-start justify-between mb-2">
+        <div>
+          <h3 className="text-white font-semibold font-mono">{source.filename}</h3>
+          <p className="text-xs text-gray-500">v{source.version} · {source.kind}</p>
+        </div>
+        {source.is_default ? (
+          <span className="text-xs px-2 py-0.5 bg-green-700 text-green-100 rounded">default</span>
+        ) : (
+          <button
+            onClick={handleSetDefault}
+            disabled={busy}
+            className="text-xs px-2 py-0.5 text-blue-300 hover:text-blue-200"
+          >
+            Make default
+          </button>
+        )}
+      </div>
+      <p className="text-xs text-gray-400 break-all mb-2">
+        <span className="text-gray-500">URL:</span> {source.url}
+      </p>
+      <p className="text-xs text-gray-400 break-all mb-3 font-mono">
+        <span className="text-gray-500 font-sans">sha256:</span> {source.expected_sha256}
+      </p>
+      {error && (
+        <div className="rounded border border-red-800 bg-red-900/30 p-2 text-xs text-red-300 mb-2">
+          {error}
+        </div>
+      )}
+      <div className="flex justify-end gap-2 pt-2 border-t border-gray-700">
+        <button
+          onClick={handleDelete}
+          disabled={busy}
+          className="text-xs px-3 py-1.5 text-red-400 hover:text-red-300"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -65,6 +65,31 @@ export interface UpdateLlmProviderData {
   api_key?: string;
 }
 
+export interface InstallerSource {
+  id: string;
+  kind: 'orion-msi';
+  url: string;
+  filename: string;
+  version: string;
+  expected_sha256: string;
+  is_default: boolean;
+  enabled: boolean;
+  created_at: string;
+}
+
+export interface ProbeInstallerResult {
+  url: string;
+  sha256: string;
+}
+
+export interface CreateInstallerSourceData {
+  url: string;
+  filename: string;
+  version: string;
+  expected_sha256: string;
+  is_default?: boolean;
+}
+
 export interface AgentEgressEvent {
   event_id: string;
   user_id: string;

--- a/migrations/010_installer_sources.sql
+++ b/migrations/010_installer_sources.sql
@@ -1,0 +1,31 @@
+-- Self-serve OrionII installer staging.
+--
+-- An admin registers one or more installer sources (URL + expected sha256 + version).
+-- When a user creates an entity, SAO downloads the *default* source (if not already cached
+-- under SAO_DATA_DIR/installers/<sha>/<filename>), verifies the sha256, and pins those
+-- coordinates on the agents row. Bundle download serves the pinned cached copy — admins
+-- no longer need shell access to stage the MSI manually.
+
+CREATE TABLE installer_sources (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    kind TEXT NOT NULL CHECK (kind IN ('orion-msi')),
+    url TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    version TEXT NOT NULL,
+    expected_sha256 TEXT NOT NULL,
+    is_default BOOLEAN NOT NULL DEFAULT false,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- At most one default per kind.
+CREATE UNIQUE INDEX idx_installer_sources_one_default
+    ON installer_sources (kind)
+    WHERE is_default = true;
+
+-- Per-agent installer pin so re-downloading the same agent's bundle gives the same MSI
+-- and old agents keep working when the default source rolls forward.
+ALTER TABLE agents ADD COLUMN installer_sha256 TEXT;
+ALTER TABLE agents ADD COLUMN installer_filename TEXT;
+ALTER TABLE agents ADD COLUMN installer_version TEXT;


### PR DESCRIPTION
Three streams of work that complete the user-self-service entity loop:

1. GET /api/orion/birth — entity-token-authenticated. Returns one rich payload (agent, endpoints, owner, scopes, current policy, personality seed) so OrionII fetches its full runtime config dynamically on every launch instead of relying on a static config.json. Admin-side changes to provider/model/policy take effect on the next launch with no re-bundling.

2. Bundle config.json slimmed to the anchor essentials (sao_base_url + agent_token), with the prior fields kept as a `fallback` block for offline-from-SAO mode and back-compat.

3. installer_sources registry — admin registers a download URL + expected sha256 + version. SAO downloads → sha-verifies → caches under SAO_DATA_DIR/installers/<sha>/. On agent create, the current default source is fetched and its coordinates pinned onto the agent row; bundle download serves the pinned cache hit, refetching by sha if the local copy is gone. Resolver chain falls back to the legacy SAO_ORION_INSTALLER_PATH env var so existing deployments keep working. The admin form pre-fills the GitHub Releases /latest/ URL convention so "set latest as default" is a one-click ritual on each release.

Plumbing:
- Migration 010: installer_sources table + agents.installer_{sha256, filename,version}; unique partial index keeps at most one default per kind.
- Admin routes: GET/POST/DELETE /api/admin/installer-sources, plus /probe (sha-of-url, no persist) and /:id/set-default. All audited.
- Frontend: AdminInstallerSourcesPage under /admin/installer-sources, sidebar entry, types + API client.
- Compose: legacy installer mount is now optional (sao-data volume holds the cache); env path is a fallback only.

End-to-end smoked: registered a source → downloaded a bundle for an unpinned agent → resolver fell back to default → fetched + verified + cached → auto-pinned the sha onto the agent → cache directory and .url traceability marker confirmed inside the container.

cargo clippy --workspace -- -D warnings clean; 50 SAO tests + 8 frontend contract tests pass.