### PR TITLE
docs: refresh runbook, MVP contract, README, and add STATUS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,26 +164,49 @@ Write-Host "SAO baseline Entra ID security groups are ready."
 
 ## Entity Lifecycle (OrionII)
 
-SAO is the issuer of OrionII entities. The full flow is in
+SAO is the issuer of OrionII entities. Canonical project status is in
+[docs/STATUS.md](docs/STATUS.md); the full local walkthrough is in
 [docs/runbooks/local-orion-sao-mvp.md](docs/runbooks/local-orion-sao-mvp.md). At a glance:
 
-1. Admin signs in, opens **/admin/llm-providers**, and per-provider:
-   - OpenAI / Anthropic / xAI Grok / Google Gemini — paste the API key, tick approved models,
-     set a default, click **Test connection** to confirm with a real ping.
-   - Ollama — set the base URL, click **Refresh models** to pull the live list, tick allowed
-     ones.
+1. Admin signs in and configures **/admin/llm-providers** (OpenAI / Anthropic / xAI Grok /
+   Google Gemini / Ollama). Each card has key-format hints, a console link, preset model list,
+   and a **Test connection** button that exercises the real upstream call path. Keys are
+   stored encrypted in the vault; admins never see the key after save. **Every entity call
+   goes through `POST /api/llm/generate` on SAO** — keys never leave the server, every prompt
+   is auditable, and key rotation/revocation is instant.
 
-   Keys are stored encrypted in the vault; admins never see the key after save. **Every entity
-   call goes through `POST /api/llm/generate` on SAO**, so keys never leave the server, every
-   prompt is auditable, and key rotation/revocation is instant.
-2. User signs in, opens **/agents**, registers a new entity (name + provider + Id/Ego model).
-3. User clicks **Download bundle**. SAO mints a fresh OIDC-shaped entity JWT (revoking any
-   prior tokens for that agent), packages a ZIP with `config.json` + `OrionII-Setup.msi`.
-4. User installs OrionII, drops `config.json` into `%APPDATA%\OrionII\`, launches the app.
-5. OrionII adopts the SAO-assigned identity, calls `POST /api/llm/generate` for every Id/Ego
-   prompt — keys never leave SAO. Per-agent egress events stream into **/agents/:id/events**.
+2. Admin registers an OrionII installer source under **/admin/installer-sources** — paste a
+   URL (convention: GitHub Releases `/releases/latest/download/<asset>`), click **Probe
+   sha256**, then **Register + warm cache**. SAO downloads, sha-verifies, and caches the MSI
+   under `SAO_DATA_DIR/installers/<sha>/`. No host shell access required. New agents auto-pin
+   to the current default's sha; existing agents keep their original pin so they stay
+   reproducible.
 
-Deleting an agent in SAO bulk-revokes its tokens.
+3. User signs in, opens **/agents**, registers a new entity (name + provider + Id/Ego model).
+
+4. User clicks **Download bundle**. SAO mints a fresh OIDC-shaped entity JWT (revoking any
+   prior tokens for that agent), packages a ZIP with `config.json` (the anchor:
+   `sao_base_url` + `agent_token`) + `OrionII-Setup.msi` (from the cached pin).
+
+5. User installs OrionII. Either drops `config.json` into `%APPDATA%\OrionII\` **or** launches
+   the app and pastes the JSON into the in-app **Enroll with SAO** panel — OrionII writes it
+   and hot-swaps the running core, no restart needed.
+
+6. On every launch, OrionII calls `GET /api/orion/birth` with the entity bearer to fetch
+   live agent metadata, endpoints, scopes, current policy, and personality seed. Admin-side
+   config changes (provider switch, model swap, policy update) take effect on the next launch
+   with no re-bundling.
+
+7. Every Id/Ego prompt POSTs to `/api/llm/generate` on SAO — keys never leave the server.
+   Per-agent egress events stream into **/agents/:id/events**.
+
+Deleting an agent in SAO bulk-revokes its tokens. Re-downloading a bundle revokes the prior
+token for that agent (one live token per agent).
+
+> Note: provider keys live in the SAO vault and are sealed at rest. Set
+> `SAO_VAULT_PASSPHRASE` so the container auto-unseals on every restart — otherwise
+> `/api/llm/generate` returns 503 (`vault is sealed`) until you POST `/api/vault/unseal`
+> from the admin UI.
 
 ## Development & Contributing
 

--- a/crates/sao-server/src/security.rs
+++ b/crates/sao-server/src/security.rs
@@ -496,7 +496,11 @@ fn is_orion_machine_request(path: &str, headers: &HeaderMap) -> bool {
         .and_then(|value| value.to_str().ok())
         .map(str::trim)
         .is_some_and(|value| value.starts_with("Bearer "));
-    has_bearer && (path == "/api/orion/egress" || path.starts_with("/api/orion/"))
+    has_bearer
+        && (path == "/api/orion/egress"
+            || path.starts_with("/api/orion/")
+            || path == "/api/llm/generate"
+            || path.starts_with("/api/llm/"))
 }
 
 fn rate_limit_bucket(method: &Method, path: &str) -> Option<(&'static str, usize, Duration)> {
@@ -580,9 +584,21 @@ mod tests {
             "/api/orion/egress",
             &headers
         ));
+        assert!(super::is_orion_machine_request(
+            "/api/orion/birth",
+            &headers
+        ));
+        assert!(super::is_orion_machine_request(
+            "/api/llm/generate",
+            &headers
+        ));
         assert!(!super::is_orion_machine_request("/api/agents", &headers));
         assert!(!super::is_orion_machine_request(
             "/api/orion/egress",
+            &HeaderMap::new()
+        ));
+        assert!(!super::is_orion_machine_request(
+            "/api/llm/generate",
             &HeaderMap::new()
         ));
     }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,10 @@ services:
       SAO_JWT_SECRET: ${SAO_JWT_SECRET:-}
       SAO_LOCAL_BOOTSTRAP: ${SAO_LOCAL_BOOTSTRAP:-false}
       SAO_LOCAL_ADMIN_USERNAME: ${SAO_LOCAL_ADMIN_USERNAME:-local-admin}
+      # Auto-unseal the vault on startup so LLM provider keys stay readable across container
+      # restarts. Read at runtime by determine_vault_state(). Use the same value you passed to
+      # bootstrap-local (SAO_LOCAL_VAULT_PASSPHRASE) — they are the same passphrase.
+      SAO_VAULT_PASSPHRASE: ${SAO_VAULT_PASSPHRASE:-${SAO_LOCAL_VAULT_PASSPHRASE:-}}
       DATABASE_URL: postgres://${POSTGRES_USER:-sao}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your environment or .env}@db:5432/${POSTGRES_DB:-sao}
       SAO_RP_ID: ${SAO_RP_ID:-localhost}
       SAO_RP_ORIGIN: ${SAO_RP_ORIGIN:-http://localhost:3100}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,147 @@
+# SAO ↔ OrionII — Project Status
+
+_Last updated: 2026-04-26_
+
+## Where we are
+
+The end-to-end self-serve entity loop is **working and verified live** against a local
+Docker Compose stack with a real Anthropic upstream:
+
+> Admin signs in → registers an installer source (GitHub Releases URL) → configures
+> Anthropic API key + Test connection → user creates an entity (auto-pinned to the default
+> installer's sha) → user clicks Download bundle → installs the MSI → launches OrionII →
+> entity calls `/api/orion/birth` and self-configures → chat input → SAO LLM proxy →
+> Anthropic Haiku 4.5 → real response in the OrionII chat panel.
+
+## What's shipped
+
+### Identity
+- **Entity JWTs** — OIDC-shaped, minted at bundle download, jti-keyed for revocation.
+  `principal_type=non_human`, `human_owner=<creating user>`, `entity_kind=orion`,
+  `scope=orion:policy orion:egress llm:generate`. Wire-shape is portable to a future Entra/IdP
+  swap.
+- **One live token per agent** — re-downloading a bundle revokes the prior token. Deleting
+  an agent bulk-revokes all of its tokens.
+
+### LLM proxy
+- `POST /api/llm/generate` — entity-token-only, dispatches to **OpenAI**, **Anthropic Claude**,
+  **xAI Grok**, **Google Gemini**, or **Ollama**.
+- Provider keys live in the SAO vault under `provider:<name>:api_key`. Entities never hold
+  upstream credentials.
+- Per-call audit (`llm.generate` / `llm.generate.failed`) with provider, model, latency,
+  error.
+- `/api/llm/*` is a machine-client route group — bypasses browser CSRF when a Bearer token is
+  present.
+
+### Admin surface (`/admin/*`)
+- `/admin/llm-providers` — per-provider catalog cards with key-format hints, console links,
+  preset model lists, **Refresh models** for Ollama, **Test connection** that exercises the
+  real upstream call path.
+- `/admin/installer-sources` — register a download URL + expected sha256 + version. SAO
+  downloads → sha-verifies → caches under `SAO_DATA_DIR/installers/<sha>/`. URL field
+  pre-fills the GitHub Releases `/releases/latest/download/` convention. **Probe sha256**
+  computes the digest before commit. Set-default and delete supported.
+
+### User surface (`/agents`, `/agents/:id/events`)
+- Agent registration wizard: name + provider + Id model + Ego model.
+- Per-card **Download bundle** (mints fresh JWT, packages cached MSI + config.json + README)
+  and **Logs** (per-agent live egress feed, polls every 5s).
+- Live `last_heartbeat` derived from the latest egress event.
+
+### Runtime config — dynamic via birth event
+- `GET /api/orion/birth` returns one rich payload: agent metadata, endpoint URLs, owner,
+  scopes, current policy, personality seed.
+- OrionII calls birth on every launch; the response overrides bundle defaults so admin
+  changes (provider switch, model swap, policy update) take effect on the next OrionII boot
+  with no re-bundling.
+- Bundle `config.json` is now an anchor (`sao_base_url` + `agent_token`); fallback fields
+  remain for offline mode.
+
+### OrionII desktop
+- Tauri 2 + React 19 shell. Boots in under a second.
+- Three status modes: **birthed** (live SAO, real LLM), **anchor only** (config loaded but
+  birth call failed — running on bundle defaults), **offline** (no anchor at all).
+- **In-app paste-config UI** — yellow "Enroll with SAO" panel visible until birth succeeds;
+  pastes the JSON, validates, writes it to `%APPDATA%\OrionII\config.json`, hot-swaps the
+  running OrionCore. No restart.
+- Identity continuity preserved across reinstalls (durable JSON state file).
+- Egress payloads stamp `clientVersion` for fleet observability.
+
+### Operational ergonomics
+- **Auto-unseal** — `SAO_VAULT_PASSPHRASE` env var unseals on startup so LLM keys stay
+  readable across container restarts. Wired through compose by default.
+- **Self-serve installer staging** — no more host-shell access required to drop an MSI on
+  the server. Admin pastes a URL; SAO downloads + verifies + caches.
+- **Sha-based pinning** — re-rolling the default installer never breaks existing agents;
+  each agent stays bound to the sha it was created with.
+
+## Verification
+
+| Gate | Status |
+|---|---|
+| `cargo clippy --workspace --all-targets -- -D warnings` (SAO) | ✅ clean |
+| `cargo test --workspace` (SAO) | ✅ 50 tests pass |
+| `npx tsc --noEmit` + `npm test` (SAO frontend) | ✅ clean, 8 contract tests pass |
+| `cargo clippy --all-targets -- -D warnings` (OrionII) | ✅ clean |
+| `cargo test` (OrionII) | ✅ 18 tests pass |
+| `npm run tauri build -- --bundles msi` | ✅ produces working MSI |
+| `docker compose config` | ✅ validates |
+| Live e2e against Anthropic Haiku 4.5 | ✅ real Claude response in OrionII chat |
+
+## What's open
+
+Tactical follow-ups (not blocking the loop):
+
+- **Markdown rendering in the OrionII chat bubble** — Claude returns `**bold**`/numbered
+  lists; today they show as raw asterisks. One-line drop-in for `react-markdown`.
+- **Streaming LLM responses** — `/api/llm/generate` is request/response only. No SSE/WS
+  streaming yet; the chat shows a static "Sending" until the full reply lands.
+- **Token-at-rest encryption in OrionII** — bundle config holds the entity JWT in plaintext
+  on disk. Threat model is local desktop, but Stronghold/DPAPI is a defensible follow-up.
+- **GitHub Releases automation for the OrionII MSI** — workflow exists at
+  [.github/workflows/release-installer.yml](https://github.com/jbcupps/OrionII/blob/main/.github/workflows/release-installer.yml);
+  needs a tag push to fire and produce assets the installer-sources registry can consume.
+- **Deep-link enrollment** — `orion://enroll?token=...` URL handler so the bundle page can
+  one-click enroll an installed OrionII without paste/file-drop.
+- **Tauri auto-updater** — install once, self-update against SAO. Needs Windows code signing
+  for trust UX.
+- **`/admin/console`** — built-in live view of the audit log + tracing stream over WebSocket
+  so admins don't have to `docker compose logs`.
+- **Per-agent provider override at runtime** — currently the agent picks one provider+model
+  at create time; consider letting the entity request a different model per call (still
+  gated by SAO's approved list).
+- **Per-provider quota / rate limit** — keys are global today. Useful when multiple entities
+  share one cloud key.
+- **Dependabot vulns** — GitHub flags 19 on the SAO default branch (7 high). Pre-existing,
+  unrelated to entity work; worth a separate sweep.
+
+## Open PRs
+
+- **SAO** — [#18 feat/orion-entity-bundle-llm-proxy](https://github.com/jbcupps/SAO/pull/18) —
+  carries everything above on the SAO side: LLM proxy + 5 providers, entity JWTs, bundle
+  endpoint, birth endpoint, installer source registry, CSRF exemption fix, auto-unseal,
+  admin pages.
+- **OrionII** —
+  [#1 fix/tauri-bundle-icon](https://github.com/jbcupps/OrionII/pull/1) (one-line) and
+  [#2 feat/dynamic-bootstrap-and-paste-ui](https://github.com/jbcupps/OrionII/pull/2)
+  (birth client + paste UI; stacked on #1 — merge #1 first).
+
+## Where to look when something breaks
+
+| What | Where |
+|---|---|
+| What just happened | `/audit` (admin-wide) or `/agents/:id/events` (per entity). |
+| LLM call failures + latencies | `audit_log` rows where `action LIKE 'llm.%'`. |
+| Why a request was rejected | `docker compose logs sao` — `tracing::warn!` lines with `request_id` you can grep against `audit_log.details->>request_id`. |
+| Vault state | `GET /api/vault/status`. |
+| Installer cache contents | `docker compose exec sao ls /data/sao/installers/`. |
+| Live chat traffic at handler depth | `RUST_LOG=sao_server=debug` then `docker compose logs -f sao`. |
+
+## Coordinates
+
+- SAO repo: <https://github.com/jbcupps/SAO>
+- OrionII repo: <https://github.com/jbcupps/OrionII>
+- Local SAO: <http://localhost:3100>
+- Runbook: [docs/runbooks/local-orion-sao-mvp.md](runbooks/local-orion-sao-mvp.md)
+- API contract: [docs/orion-sao-mvp.md](orion-sao-mvp.md)
+- Architecture: [docs/architecture.md](architecture.md)

--- a/docs/orion-sao-mvp.md
+++ b/docs/orion-sao-mvp.md
@@ -127,6 +127,61 @@ Returns 503 if the installer is not staged with a clear remediation message.
 Lists `orion_egress_events` rows for the agent. Pagination via `?limit=&offset=`. Backs the
 `/agents/:id/events` page in the SAO UI.
 
+### `GET /api/orion/birth` *(entity bearer ONLY)*
+
+Returns one rich payload OrionII uses to seed its runtime config on every launch:
+
+```json
+{
+  "birthedAt": "2026-04-26T21:17:30Z",
+  "clientVersionMin": "0.1.0",
+  "agent": {
+    "id": "...", "name": "abigail", "createdAt": "...",
+    "defaultProvider": "anthropic",
+    "defaultIdModel": "claude-haiku-4-5-20251001",
+    "defaultEgoModel": "claude-haiku-4-5-20251001"
+  },
+  "endpoints": {
+    "saoBaseUrl": "http://localhost:3100",
+    "policyUrl": "/api/orion/policy",
+    "egressUrl": "/api/orion/egress",
+    "llmUrl": "/api/llm/generate",
+    "birthUrl": "/api/orion/birth"
+  },
+  "owner": { "userId": "...", "username": "local-admin" },
+  "scopes": ["orion:policy", "orion:egress", "llm:generate"],
+  "policy": { "version": 1, "source": "sao", "rules": [...], "updatedAt": "..." },
+  "personalitySeed": { "name": "...", "stance": "...", "drives": [...], "deontological": 0.34, "virtue": 0.33, "consequential": 0.33 }
+}
+```
+
+Audit: `orion.birth` (attributed to `human_owner` from the JWT). Rejects user JWTs with 403.
+
+### Admin installer-source registry
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/api/admin/installer-sources` | List all registered sources. |
+| POST | `/api/admin/installer-sources/probe` | Body `{ "url": "..." }`. Computes sha256 of upstream without persisting. |
+| POST | `/api/admin/installer-sources` | Body: kind=`orion-msi` (default), url, filename, version, expected_sha256 (64-hex), is_default. Pre-warms the cache; idempotent on duplicate sha. |
+| POST | `/api/admin/installer-sources/:id/set-default` | Promote a source to the default. |
+| DELETE | `/api/admin/installer-sources/:id` | Delete a source row. Cached files on disk are not GC'd by this call. |
+
+Cache layout under `SAO_DATA_DIR/installers/`:
+```
+<sha>/
+  <filename>          -- the verified artifact
+  .url                -- the source URL for traceability
+```
+
+`agents.installer_sha256/installer_filename/installer_version` pin a specific artifact to an
+agent. The bundle endpoint resolves in order:
+
+1. Pinned cache hit (re-verifies sha on every serve).
+2. Pinned-by-sha refetch from the matching `installer_sources` row when the cache file is missing.
+3. Default source fetch + auto-pin (covers agents created before any source existed).
+4. Legacy `SAO_ORION_INSTALLER_PATH` env var (back-compat with mount-based deployments).
+
 ### Admin LLM provider management
 
 Supported providers: `openai`, `anthropic`, `grok` (xAI), `gemini` (Google), `ollama` (local).
@@ -183,8 +238,25 @@ Three identities, three token shapes:
 
 ## CSRF Boundary
 
-`/api/orion/*` and `/api/llm/generate` are machine-client route groups. They accept Bearer auth
-and bypass browser CSRF. The general browser API keeps CSRF and origin enforcement intact.
+`/api/orion/*` and `/api/llm/*` are machine-client route groups. They accept Bearer auth and
+bypass browser CSRF (see `is_orion_machine_request` in [security.rs](crates/sao-server/src/security.rs)).
+The general browser API keeps CSRF and origin enforcement intact. Admin routes (including
+`/api/admin/installer-sources/*` and `/api/admin/llm-providers/*`) require browser sessions and
+CSRF tokens — they cannot be exercised from a curl/bearer flow without first attaching a
+session cookie.
+
+## Vault unseal
+
+The vault holds provider API keys (`provider:<name>:api_key`) and OIDC client secrets
+encrypted under a passphrase-derived KEK. After every container restart it boots **sealed** —
+the LLM proxy returns 503 (`vault is sealed; cannot read provider key`) until something
+unseals it. Two paths:
+
+1. **Manual** — admin browser → `POST /api/vault/unseal` with the passphrase.
+2. **Auto** (recommended for local dev) — set `SAO_VAULT_PASSPHRASE` in the SAO container
+   environment. `determine_vault_state` reads it on startup and unseals automatically. The
+   compose file already wires `SAO_VAULT_PASSPHRASE` from `SAO_LOCAL_VAULT_PASSPHRASE` for
+   convenience.
 
 ## Idempotency
 

--- a/docs/runbooks/local-orion-sao-mvp.md
+++ b/docs/runbooks/local-orion-sao-mvp.md
@@ -1,19 +1,17 @@
 # Local OrionII + SAO MVP Runbook
 
-End-to-end walkthrough: log in → admin configures Ollama → user creates an entity → downloads the
-bundle → installs OrionII → entity phones home and chats through the SAO LLM proxy.
+End-to-end walkthrough — admin configures provider keys + an installer source, a user creates an
+entity, downloads a self-contained bundle, and the entity births dynamically and chats through
+SAO's LLM proxy.
 
 ## Prerequisites
 
 - Rust stable, Node.js 24, npm, Docker Desktop, PowerShell.
 - SAO checked out at `C:\Repo\SAO`, OrionII at `C:\Repo\OrionII`.
-- A locally running Ollama (or a Docker-network-reachable one) — required for the closed loop.
-- A local-only `SAO_JWT_SECRET` shared across SAO and OrionII (for the dev fallback path; the
-  bundle flow is fully self-contained once the bundle is downloaded).
+- An API key for at least one cloud LLM provider (OpenAI / Anthropic / Grok / Gemini), OR a
+  reachable Ollama instance.
 
-## 1. Build the OrionII installer (one-time per code change)
-
-The bundle endpoint serves a real `.msi`. Build it before the first run:
+## 1. Build the OrionII installer (one-time per OrionII code change)
 
 ```powershell
 cd C:\Repo\OrionII
@@ -21,16 +19,10 @@ npm ci
 npm run tauri build -- --bundles msi
 ```
 
-This produces an installer at:
+Output: `src-tauri/target/release/bundle/msi/OrionII_<version>_x64_en-US.msi`. SAO will fetch
+this from a URL you give it later — see step 4.
 
-```
-C:\Repo\OrionII\src-tauri\target\release\bundle\msi\OrionII_0.1.0_x64_en-US.msi
-```
-
-## 2. Start SAO with the installer mount
-
-The SAO container can't see host filesystem paths, so we mount the OrionII MSI directory into
-the container and tell the bundle endpoint where to find it:
+## 2. Start SAO
 
 ```powershell
 cd C:\Repo\SAO
@@ -38,18 +30,15 @@ $env:POSTGRES_PASSWORD            = "local-dev-only-change-me"
 $env:SAO_JWT_SECRET               = "local-dev-only-change-me"
 $env:SAO_LOCAL_BOOTSTRAP          = "true"
 $env:SAO_LOCAL_ADMIN_USERNAME     = "local-admin"
-# Bundle endpoint config — embedded in every config.json:
+$env:SAO_LOCAL_VAULT_PASSPHRASE   = "local-dev-only-change-me"
+# Auto-unseal the vault on every container start so LLM provider keys stay readable
+# without a manual unseal step:
+$env:SAO_VAULT_PASSPHRASE         = "local-dev-only-change-me"
+# Embedded into every config.json so OrionII knows where to phone home:
 $env:SAO_PUBLIC_BASE_URL          = "http://localhost:3100"
-# Installer mount (host path) + filename — Compose mounts this dir read-only at /installer:
-$env:SAO_ORION_INSTALLER_DIR      = "C:\Repo\OrionII\src-tauri\target\release\bundle\msi"
-$env:SAO_ORION_INSTALLER_FILENAME = "OrionII_0.1.0_x64_en-US.msi"
 
-docker compose -f docker\docker-compose.yml up --build
+docker compose -f docker\docker-compose.yml up --build -d
 ```
-
-If you're not yet ready to serve installers, omit `SAO_ORION_INSTALLER_DIR` —
-Compose falls back to an empty placeholder mount, and the bundle endpoint returns a 503 with a
-clear remediation message until you stage the MSI.
 
 In a second window, run the bootstrap:
 
@@ -63,146 +52,188 @@ $env:SAO_LOCAL_ADMIN_USERNAME     = "local-admin"
 docker compose -f docker\docker-compose.yml run --rm sao sao-server bootstrap-local
 ```
 
-Browse to `http://localhost:3100`, register Windows Hello for `local-admin`, then sign in.
+Confirm `bootstrap_mode: operational` and the vault is unsealed:
+
+```powershell
+Invoke-RestMethod http://localhost:3100/api/setup/status
+Invoke-RestMethod http://localhost:3100/api/vault/status   # status: "unsealed"
+```
+
+Open `http://localhost:3100`, register Windows Hello for `local-admin`, then sign in.
 
 ## 3. (Admin) Configure LLM providers
 
-Go to **/admin/llm-providers**. Each provider has its own card. Configure as many as you want;
-entities pick one at creation time and SAO routes their `/api/llm/generate` calls to it.
+Go to **/admin/llm-providers**. Each provider has its own card:
 
-### Cloud providers (OpenAI, Anthropic Claude, xAI Grok, Google Gemini)
+### Cloud (OpenAI / Anthropic Claude / xAI Grok / Google Gemini)
 
-For each one you want to enable:
+1. Get a key from the provider console (link is on the card):
+   - OpenAI `sk-...` — https://platform.openai.com/api-keys
+   - Anthropic `sk-ant-...` — https://console.anthropic.com/settings/keys
+   - Grok `xai-...` — https://console.x.ai/
+   - Gemini `AIza...` — https://aistudio.google.com/apikey
+2. Toggle **Enabled**.
+3. Paste the key (write-only).
+4. Tick the preset models you want allowed (or paste comma-separated overrides).
+5. Set **Default model**.
+6. Click **Save**, then **Test connection** — SAO sends a real ping prompt and surfaces
+   latency + preview text.
 
-1. Get an API key from the provider console linked under the key field:
-   - OpenAI: `sk-...` from https://platform.openai.com/api-keys
-   - Anthropic: `sk-ant-...` from https://console.anthropic.com/settings/keys
-   - Grok: `xai-...` from https://console.x.ai/
-   - Gemini: `AIza...` from https://aistudio.google.com/apikey
-2. Toggle **Enabled** on.
-3. Paste the key into **API key** (write-only — never returned by GET).
-4. Tick the preset models you want to allow, or paste comma-separated overrides.
-5. Set **Default model** (auto-filled from the provider's preset).
-6. Click **Save**. The vault encrypts the key at rest under
-   `(provider=<name>, label='api_key', secret_type='api_key')`.
-7. Click **Test connection** — SAO sends a tiny ping prompt through the real provider path and
-   surfaces the latency + preview text or the upstream error.
+### Ollama
 
-### Ollama (local self-hosted)
+Set the base URL (`http://host.docker.internal:11434` from inside the SAO container), click
+**Refresh models** to pull the live `/api/tags`, tick what you want, save, test.
 
-1. Toggle **Enabled** on.
-2. Set base URL — from the SAO container, the host's Ollama is at
-   `http://host.docker.internal:11434`.
-3. Click **Refresh models** — the live `/api/tags` response populates a checkbox list.
-4. Tick the models you want to allow.
-5. Set **Default model** (e.g., `llama3.2`).
-6. Click **Save**, then **Test connection**.
+## 4. (Admin) Register the OrionII installer source
 
-> Whichever provider you enable, the entity always calls SAO. There is no direct entity → upstream
-> path. Switching providers, rotating a key, or revoking a token in SAO applies instantly without
-> touching any installed entity.
+Go to **/admin/installer-sources** → **+ Register installer source**:
 
-## 4. (User) Create an entity
+1. Paste a download URL — convention is the GitHub Releases `latest` URL:
+   ```
+   https://github.com/jbcupps/OrionII/releases/latest/download/OrionII_0.1.0_x64_en-US.msi
+   ```
+   (Or any URL SAO can `GET`.)
+2. Click **Probe sha256** — SAO computes the digest of what it sees at that URL.
+3. Confirm the sha matches what you expect, then fill **Filename** + **Version label** (the
+   form pre-fills sensible defaults).
+4. Tick **Make this the default**.
+5. Click **Register + warm cache** — SAO downloads, sha-verifies, and writes the file under
+   `SAO_DATA_DIR/installers/<sha>/`.
 
-Go to **/agents** → **+ Register Agent**:
+After this, every new agent gets pinned to that sha at create time, and bundle downloads
+serve straight from the local cache. No host-side MSI staging required.
 
-1. **Name**: e.g. `abigail`.
-2. **LLM Provider**: choose `ollama`.
-3. **Id model** / **Ego model**: `llama3.2` (autofills from provider default).
+## 5. (User) Create an entity
+
+Visit **/agents** → **+ Register Agent**:
+
+1. Name (e.g., `abigail`).
+2. LLM provider (dropdown of admin-enabled providers).
+3. Id model + Ego model (autofill from the provider's default).
 4. Click **Register**.
 
-A new card appears with the agent's UUID, `LLM: ollama / llama3.2 / llama3.2`, status `offline`.
+The new card shows the agent's UUID, the chosen LLM, and an `offline` badge. The agent row in
+the DB now has the current default installer's sha pinned to it.
 
-## 5. (User) Download the bundle
+## 6. (User) Download the bundle
 
-Click **Download bundle** on the agent card. A file like
-`Orion-abigail-12345678.zip` downloads. Inside:
+Click **Download bundle**. SAO mints a fresh OIDC-shaped entity JWT (revoking any prior tokens
+for that agent), packages a ZIP from the cached MSI, and audit-logs `agents.bundle_downloaded`.
+
+The ZIP contains:
 
 | File | Purpose |
 |---|---|
-| `config.json` | SAO base URL, agent_id, **entity JWT**, default models. |
-| `OrionII-Setup.msi` | Tauri installer. |
-| `README-FIRST-RUN.txt` | Install steps. |
+| `config.json` | SAO base URL + entity JWT (the anchor). Two extra fields are kept as
+fallback for offline mode + back-compat. |
+| `OrionII-Setup.msi` | Tauri installer for Windows. |
+| `README-FIRST-RUN.txt` | Install steps for the user. |
 
-The download mints a fresh entity JWT, revokes any prior tokens for that agent, and audit-logs
-`agents.bundle_downloaded`.
-
-## 6. Install + run OrionII
+## 7. Install + run OrionII
 
 1. Run `OrionII-Setup.msi` and finish the install wizard.
-2. Drop `config.json` into `%APPDATA%\OrionII\config.json` (create the folder if needed).
-   The bootstrap loader also accepts `config.json` co-located with the executable.
-3. Launch OrionII.
+2. **Either** drop `config.json` into `%APPDATA%\OrionII\config.json`,
+   **or** launch OrionII first and paste the JSON into the yellow **Enroll with SAO** panel
+   that appears in the app — click **Apply config** and OrionII writes it for you and
+   hot-swaps the running core (no restart needed).
+3. The status card flips from `offline` → `birthed`, showing
+   `Birthed as <name> via <provider> (policy v1)` plus owner / id-model / ego-model.
 
-On first launch:
-- Bootstrap reads `config.json` and adopts the SAO-assigned `agent_id` as the local
-  `orion_id`.
-- The model router is configured for `SaoProxyWithFallback` against the chosen provider.
-- The first chat call goes out as `POST {sao_base_url}/api/llm/generate` with the entity JWT.
+On launch:
+- Bootstrap reads `config.json` (sao_base_url + entity JWT).
+- Calls `GET /api/orion/birth` to fetch live agent metadata, endpoints, scopes, current
+  policy, personality seed.
+- Adopts the SAO-assigned `agent_id` as the local `orion_id`.
+- The model router is in `SaoProxyWithFallback` mode: every Id/Ego prompt POSTs to
+  `/api/llm/generate` with `Authorization: Bearer <entity-JWT>`. Keys never leave SAO.
 
-Type a message in OrionII; you should see a real response from `llama3.2` proxied through SAO.
+## 8. Verify the loop
 
-## 7. Verify the loop
+In SAO:
 
-Back in SAO:
+- **/agents** — badge turns `active` after the first egress event.
+- **Logs** button on the agent card → **/agents/:id/events** — `identitySync`, `auditAction`,
+  `memoryEvent` rows arrive every few seconds (page polls).
+- **/audit** — `llm.generate` rows show provider/model/latency_ms; `agents.bundle_downloaded`,
+  `orion.egress`, `orion.birth` are attributed to the human owner.
 
-- **/agents** — the badge should turn `active` after the first egress event lands.
-- Click **Logs** on the agent card → **/agents/:id/events** — see `identitySync`, `auditAction`,
-  and (if you indexed a doc) `memoryEvent` rows trickle in (page polls every 5s).
-- **/audit** — see `llm.generate`, `agents.bundle_downloaded`, `orion.egress` rows attributed to
-  the human owner with the agent_id surfaced.
+In OrionII:
 
-## 8. Re-issue / revoke
+- Status card shows `birthed`, owner, provider, models.
+- Send a chat message — you should see a real model response (no longer the deterministic
+  fallback "Orion is operating as a persistent local companion..." stub).
 
-- **Re-download**: clicking **Download bundle** again revokes the old token and mints a new
-  one — install the new config.json and restart OrionII.
-- **Delete**: deleting the agent in SAO bulk-revokes all tokens for that agent. The next
-  `/api/orion/policy` or `/api/llm/generate` call from the old install returns 401.
+## 9. Re-issue / revoke
 
-## Dev/legacy fallback flow (no bundle)
+- **Re-download bundle** — revokes the old token and mints a new one. Re-paste the new
+  config.json (or drop it into `%APPDATA%\OrionII\` again).
+- **Delete the agent in SAO** — bulk-revokes all of its tokens. Subsequent `/api/orion/policy`
+  / `/api/llm/generate` calls from the old install return 401.
+- **Roll the installer source forward** — register a new source with a new sha, set as
+  default. New agents pin to the new sha; existing agents keep their original pin so they
+  stay reproducible.
 
-The original env-driven path still works for development:
+## What lives where on disk (inside the container)
+
+| Path | Contents |
+|---|---|
+| `/data/sao/jwt_secret.bin` | Local JWT signing key (persists across restarts). |
+| `/data/sao/installers/<sha>/<filename>` | sha256-verified installer cache. |
+| `/data/sao/installers/<sha>/.url` | Source URL marker for traceability. |
+| Postgres `installer_sources` | Registered MSI sources (URL, expected sha, version, default). |
+| Postgres `agents.installer_sha256/filename/version` | Per-agent pin. |
+| Postgres `agent_tokens` | jti-keyed revocation rows for entity JWTs. |
+| Postgres `orion_egress_events` | Idempotent ingress of OrionII events. |
+| Postgres `audit_log` | All authenticated actions + LLM proxy calls. |
+
+## Watching live activity (the SAO console)
 
 ```powershell
-cd C:\Repo\OrionII
-$env:SAO_BASE_URL          = "http://localhost:3100"
-$env:SAO_DEV_BEARER_TOKEN  = (docker compose -f C:\Repo\SAO\docker\docker-compose.yml run --rm sao sao-server mint-dev-token | Select-Object -Last 1)
-$env:SAO_AGENT_ID          = "<optional>"
-npm run tauri dev
+# tail everything
+docker compose -f docker\docker-compose.yml logs -f sao
+
+# just LLM/orion-related lines
+docker compose -f docker\docker-compose.yml logs -f sao | Select-String "llm|orion|generate|birth"
+
+# debug-level (handler entry/exit, request bodies on warns)
+$env:RUST_LOG = "sao_server=debug,axum=info"
+docker compose -f docker\docker-compose.yml up -d
 ```
 
-In this mode the bearer is a user JWT (admin acting as the entity) and the model layer falls back
-to local Ollama (no SAO LLM proxy). Useful for iterating on OrionII before rebuilding the MSI.
+For the canonical record of what happened, query the audit log directly:
+
+```sql
+SELECT created_at, action, details->>'model' AS model,
+       details->>'latency_ms' AS ms, details->>'error' AS error
+FROM audit_log WHERE action LIKE 'llm.%' ORDER BY created_at DESC LIMIT 20;
+```
 
 ## Troubleshooting
 
-- `503 OrionII installer is not staged` from the bundle endpoint — set
-  `SAO_ORION_INSTALLER_DIR` + `SAO_ORION_INSTALLER_FILENAME` and re-run `docker compose up`
-  (the directory is mounted into the container at `/installer`).
-- `400 Agent has no default LLM provider configured` — the agent was created before the wizard
-  fields existed. Delete and recreate it.
-- `400 Configured provider is currently disabled` — admin disabled the provider after the agent
-  was created. Re-enable in `/admin/llm-providers`.
-- Ollama probe returns `connection refused` from the SAO container — use
-  `http://host.docker.internal:11434` instead of `127.0.0.1`.
-- SAO LLM proxy returns 502 with `connection refused` — same fix; check the OrionII container
-  can reach the host's Ollama.
-- Entity JWT decoded but **revoked** — someone deleted the agent or downloaded a fresh bundle.
-  Download again.
+| Symptom | Cause | Fix |
+|---|---|---|
+| `503 OrionII installer is not available` | No installer source registered AND no `SAO_ORION_INSTALLER_PATH` env var. | Register a source under `/admin/installer-sources` (preferred) or set the env var to a mounted MSI path. |
+| Bundle download 503 with sha-mismatch | Cached file doesn't match registered sha (substituted upstream / corruption). | SAO refetches automatically on the next call; if upstream is permanently gone, register a new source. |
+| OrionII shows `Degraded fallback` for MODEL after a fresh container start | Vault is sealed → LLM proxy can't decrypt the API key. | Set `SAO_VAULT_PASSPHRASE` so compose auto-unseals on startup. |
+| OrionII chat returns the deterministic fallback text | `/api/llm/generate` is failing — check `audit_log` for `llm.generate.failed`. | Common causes: vault sealed, model not on approved list, upstream API rejected the key. |
+| `503 Vault is sealed` on the LLM endpoint | Same as above. | Set `SAO_VAULT_PASSPHRASE`. |
+| `400 Configured provider is currently disabled` | Admin disabled the provider after the agent was created. | Re-enable in `/admin/llm-providers`. |
+| Ollama probe `connection refused` from container | `127.0.0.1` doesn't reach the host. | Use `http://host.docker.internal:11434`. |
+| Entity token returns 401 | Token revoked (agent deleted, or new bundle downloaded). | Download a fresh bundle, re-paste config. |
+| `release-installer` workflow fails on icon | Missing `bundle.icon` in `tauri.conf.json`. | Already fixed in OrionII PR #1 — make sure it's merged. |
 
-## Validation Gate
-
-Run before calling MVP green:
+## Validation Gate (before declaring MVP green)
 
 ```powershell
 cd C:\Repo\SAO
 cargo test --workspace
-cargo clippy --workspace -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings
 npm --prefix frontend test
 
 cd C:\Repo\OrionII
 npm ci
 npm run build
 cargo test --manifest-path src-tauri\Cargo.toml --locked
-cargo clippy --manifest-path src-tauri\Cargo.toml --locked -- -D warnings
+cargo clippy --manifest-path src-tauri\Cargo.toml --locked --all-targets -- -D warnings
+npm run tauri build -- --bundles msi
 ```


### PR DESCRIPTION
Brings all SAO docs in line with what's actually shipped this session:

- runbooks/local-orion-sao-mvp.md — full e2e walkthrough now covers the self-serve installer-source flow (probe sha + register + warm cache), the SAO_VAULT_PASSPHRASE auto-unseal env wiring, the CSRF boundary for /api/llm/* and /api/orion/*, a new "watching live activity" section (logs + audit_log queries), and a troubleshooting matrix.
- orion-sao-mvp.md — adds the GET /api/orion/birth response shape, the installer-source admin endpoints + cache layout + bundle resolver chain, and the new vault-unseal section. CSRF boundary now correctly documents /api/llm/* as a machine route group.
- README.md — Entity Lifecycle section rewritten as 7 ordered steps that match the live UX (admin keys → installer source → user create → bundle download → install → birth → chat). Calls out the SAO_VAULT_PASSPHRASE requirement explicitly.
- docs/STATUS.md (new) — canonical "where we are" doc: shipped capabilities, verification gates (all green), open follow-ups, open PRs, and a "where to look when something breaks" table.

No code changes; cargo clippy + 50 tests still pass.