### PR TITLE
[codex] Ship OrionII bundle installer MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ external_pubkey.bin
 *.db
 *.db-wal
 *.db-shm
+docker/empty-installer-mount/*.msi
 
 # IDE
 .idea/

--- a/COORDINATION.md
+++ b/COORDINATION.md
@@ -4,10 +4,18 @@ The local OrionII integration MVP is coordinated by these docs:
 
 - `docs/orion-sao-mvp.md` for the shared API contract.
 - `docs/runbooks/local-orion-sao-mvp.md` for the local end-to-end runbook.
+- `docs/runbooks/verify-orion-topic-shift.md` for SAO-side verification of OrionII internal transport changes.
 - `C:\Repo\OrionII\docs\sao-mvp-client.md` for OrionII client behavior.
 
 Keep browser auth cookie-based and CSRF-protected. The Orion MVP uses a separate Bearer-authenticated
 machine route group under `/api/orion`.
+
+OrionII transport boundary:
+
+- SAO packages OrionII with `bus_transport: { kind: "nats_jetstream", port: 4222 }` so the entity
+  runtime prefers durable local topics.
+- SAO does not run or join that bus. SAO remains the external birth, policy, LLM-proxy, and
+  sanitized-egress HTTP seam.
 
 Bootstrap boundaries:
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,18 @@ To validate the local SAO side of the OrionII integration:
 .\scripts\local-mvp-smoke.ps1 -StartCompose -OllamaBaseUrl "http://host.docker.internal:11434" -OllamaModel "llama3.2"
 ```
 
+To verify the bundle-issued entity contract itself from the SAO side:
+
+```powershell
+# Prepare a fresh bundle + report for a manual OrionII two-window run.
+.\scripts\verify-orion-topic-shift.ps1 -Provider "anthropic" -IdModel "claude-haiku-4-5-20251001" -EgoModel "claude-haiku-4-5-20251001" -PrepareOnly
+
+# Or exercise birth -> llm.generate -> egress directly with the real entity JWT.
+.\scripts\verify-orion-topic-shift.ps1 -Provider "anthropic" -IdModel "claude-haiku-4-5-20251001" -EgoModel "claude-haiku-4-5-20251001" -RunRegressionChecks
+```
+
+See `docs/runbooks/verify-orion-topic-shift.md` for the full SAO-side verification procedure.
+
 To serve real OrionII installers from `/api/agents/:id/bundle`, build the MSI in OrionII first and
 point Compose at it via two host env vars before running `up`:
 

--- a/crates/sao-server/src/auth/agent_tokens.rs
+++ b/crates/sao-server/src/auth/agent_tokens.rs
@@ -88,7 +88,8 @@ pub async fn mint_entity_token(
     let now = Utc::now();
     let expires_at = now + Duration::days(DEFAULT_TTL_DAYS);
 
-    let row = db::insert_token(pool, agent_id, issuer_user, Some(expires_at), DEFAULT_SCOPE).await?;
+    let row =
+        db::insert_token(pool, agent_id, issuer_user, Some(expires_at), DEFAULT_SCOPE).await?;
 
     let claims = AgentClaims {
         iss: ISSUER.to_string(),
@@ -140,7 +141,9 @@ pub async fn validate_entity_token(
         .ok_or(AgentTokenError::Invalid("token revoked or unknown"))?;
 
     if row.agent_id.to_string() != claims.sub {
-        return Err(AgentTokenError::Invalid("sub does not match revocation row"));
+        return Err(AgentTokenError::Invalid(
+            "sub does not match revocation row",
+        ));
     }
 
     let _ = db::touch_last_used(pool, jti).await;
@@ -185,9 +188,8 @@ mod tests {
         let mut validation = Validation::default();
         validation.set_audience(&[AUDIENCE]);
         validation.set_issuer(&[ISSUER]);
-        let decoded =
-            decode::<AgentClaims>(&jwt, &DecodingKey::from_secret(&secret), &validation)
-                .expect("decode");
+        let decoded = decode::<AgentClaims>(&jwt, &DecodingKey::from_secret(&secret), &validation)
+            .expect("decode");
 
         assert_eq!(decoded.claims.entity_name, "abigail");
         assert_eq!(decoded.claims.principal_type, PRINCIPAL_TYPE_NON_HUMAN);
@@ -224,9 +226,8 @@ mod tests {
         let mut validation = Validation::default();
         validation.set_audience(&[AUDIENCE]);
         validation.set_issuer(&[ISSUER]);
-        let decoded =
-            decode::<AgentClaims>(&jwt, &DecodingKey::from_secret(&secret), &validation)
-                .expect("decode");
+        let decoded = decode::<AgentClaims>(&jwt, &DecodingKey::from_secret(&secret), &validation)
+            .expect("decode");
         assert_ne!(decoded.claims.principal_type, PRINCIPAL_TYPE_NON_HUMAN);
     }
 }

--- a/crates/sao-server/src/db/agents.rs
+++ b/crates/sao-server/src/db/agents.rs
@@ -84,24 +84,21 @@ pub async fn create_agent(
 }
 
 pub async fn get_agent(pool: &PgPool, id: Uuid) -> Result<Option<AgentRow>, sqlx::Error> {
-    sqlx::query_as::<_, AgentRow>(&format!(
-        "SELECT {SELECT_COLS} FROM agents WHERE id = $1"
-    ))
-    .bind(id)
-    .fetch_optional(pool)
-    .await
+    sqlx::query_as::<_, AgentRow>(&format!("SELECT {SELECT_COLS} FROM agents WHERE id = $1"))
+        .bind(id)
+        .fetch_optional(pool)
+        .await
 }
 
 pub async fn last_egress_at(
     pool: &PgPool,
     agent_id: Uuid,
 ) -> Result<Option<chrono::DateTime<chrono::Utc>>, sqlx::Error> {
-    let row: Option<(Option<chrono::DateTime<chrono::Utc>>,)> = sqlx::query_as(
-        "SELECT MAX(created_at) FROM orion_egress_events WHERE agent_id = $1",
-    )
-    .bind(agent_id)
-    .fetch_optional(pool)
-    .await?;
+    let row: Option<(Option<chrono::DateTime<chrono::Utc>>,)> =
+        sqlx::query_as("SELECT MAX(created_at) FROM orion_egress_events WHERE agent_id = $1")
+            .bind(agent_id)
+            .fetch_optional(pool)
+            .await?;
     Ok(row.and_then(|r| r.0))
 }
 

--- a/crates/sao-server/src/db/installer_sources.rs
+++ b/crates/sao-server/src/db/installer_sources.rs
@@ -92,10 +92,11 @@ pub async fn set_default(
     id: Uuid,
 ) -> Result<Option<InstallerSourceRow>, sqlx::Error> {
     let mut tx = pool.begin().await?;
-    let kind: Option<(String,)> = sqlx::query_as("SELECT kind FROM installer_sources WHERE id = $1")
-        .bind(id)
-        .fetch_optional(&mut *tx)
-        .await?;
+    let kind: Option<(String,)> =
+        sqlx::query_as("SELECT kind FROM installer_sources WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&mut *tx)
+            .await?;
     let Some((kind,)) = kind else {
         return Ok(None);
     };

--- a/crates/sao-server/src/llm/gemini.rs
+++ b/crates/sao-server/src/llm/gemini.rs
@@ -102,12 +102,19 @@ pub async fn generate(api_key: &str, req: &GenerateRequest) -> Result<String, Ll
     let parsed: GenerateContentResponse =
         serde_json::from_str(&text).map_err(|e| LlmError::BadResponse(e.to_string()))?;
 
-    if parsed.candidates.as_ref().map(|c| c.is_empty()).unwrap_or(true) {
+    if parsed
+        .candidates
+        .as_ref()
+        .map(|c| c.is_empty())
+        .unwrap_or(true)
+    {
         let reason = parsed
             .prompt_feedback
             .map(|v| v.to_string())
             .unwrap_or_else(|| "no candidates".to_string());
-        return Err(LlmError::BadResponse(format!("Gemini returned no candidates: {reason}")));
+        return Err(LlmError::BadResponse(format!(
+            "Gemini returned no candidates: {reason}"
+        )));
     }
 
     parsed

--- a/crates/sao-server/src/llm/mod.rs
+++ b/crates/sao-server/src/llm/mod.rs
@@ -70,8 +70,8 @@ pub async fn dispatch(
         return Err(LlmError::ProviderDisabled(req.provider.clone()));
     }
 
-    let approved: Vec<String> = serde_json::from_value(settings.approved_models.clone())
-        .unwrap_or_default();
+    let approved: Vec<String> =
+        serde_json::from_value(settings.approved_models.clone()).unwrap_or_default();
     if !approved.is_empty() && !approved.iter().any(|m| m == &req.model) {
         return Err(LlmError::ModelNotApproved {
             provider: req.provider.clone(),

--- a/crates/sao-server/src/routes/admin.rs
+++ b/crates/sao-server/src/routes/admin.rs
@@ -31,7 +31,10 @@ pub fn routes() -> Router<AppState> {
         .route("/api/admin/audit", get(query_audit_log))
         // LLM provider configuration (admin only)
         .route("/api/admin/llm-providers", get(list_llm_providers))
-        .route("/api/admin/llm-providers/:provider", put(update_llm_provider))
+        .route(
+            "/api/admin/llm-providers/:provider",
+            put(update_llm_provider),
+        )
         .route(
             "/api/admin/llm-providers/ollama/probe",
             post(probe_ollama_models),
@@ -42,7 +45,10 @@ pub fn routes() -> Router<AppState> {
         )
         // OrionII installer source registry (admin only)
         .route("/api/admin/installer-sources", get(list_installer_sources))
-        .route("/api/admin/installer-sources", post(create_installer_source))
+        .route(
+            "/api/admin/installer-sources",
+            post(create_installer_source),
+        )
         .route(
             "/api/admin/installer-sources/probe",
             post(probe_installer_source),
@@ -57,8 +63,7 @@ pub fn routes() -> Router<AppState> {
         )
 }
 
-const SUPPORTED_PROVIDERS: &[&str] =
-    &["openai", "anthropic", "ollama", "grok", "gemini"];
+const SUPPORTED_PROVIDERS: &[&str] = &["openai", "anthropic", "ollama", "grok", "gemini"];
 const KEY_BEARING_PROVIDERS: &[&str] = &["openai", "anthropic", "grok", "gemini"];
 
 // --- User management ---
@@ -499,7 +504,9 @@ async fn update_llm_provider(
         );
     }
 
-    if provider == "ollama" && req.enabled && req.base_url.as_deref().unwrap_or("").trim().is_empty()
+    if provider == "ollama"
+        && req.enabled
+        && req.base_url.as_deref().unwrap_or("").trim().is_empty()
     {
         return (
             StatusCode::BAD_REQUEST,
@@ -558,10 +565,7 @@ async fn update_llm_provider(
         }
     }
 
-    let approved_models = req
-        .approved_models
-        .clone()
-        .unwrap_or_else(|| json!([]));
+    let approved_models = req.approved_models.clone().unwrap_or_else(|| json!([]));
 
     let saved = match crate::db::llm_providers::upsert(
         &state.inner.db,
@@ -692,10 +696,7 @@ async fn test_llm_provider(
         provider: provider.clone(),
         model: model.clone(),
         system: "You are a connectivity test for SAO. Reply briefly.".to_string(),
-        prompt: req
-            .prompt
-            .clone()
-            .unwrap_or_else(|| "ping".to_string()),
+        prompt: req.prompt.clone().unwrap_or_else(|| "ping".to_string()),
         temperature: 0.0,
         role: "test".to_string(),
     };
@@ -713,7 +714,9 @@ async fn test_llm_provider(
         },
         "anthropic" => match crate::llm::keys::get_api_key(&state, "anthropic").await {
             Ok(Some(key)) => crate::llm::anthropic::generate(&key, &test_req).await,
-            Ok(None) => Err(crate::llm::LlmError::ProviderUnconfigured("anthropic".into())),
+            Ok(None) => Err(crate::llm::LlmError::ProviderUnconfigured(
+                "anthropic".into(),
+            )),
             Err(e) => Err(e),
         },
         "grok" => match crate::llm::keys::get_api_key(&state, "grok").await {

--- a/crates/sao-server/src/routes/agents.rs
+++ b/crates/sao-server/src/routes/agents.rs
@@ -174,8 +174,7 @@ async fn create_agent(
     )
     .await;
     crate::db::audit::log_birth_event(&identity_agent_id);
-    let ethic_preview =
-        sao_core::ethical_bridge::get_triangleethic_preview(&identity_agent_id);
+    let ethic_preview = sao_core::ethical_bridge::get_triangleethic_preview(&identity_agent_id);
     (
         StatusCode::CREATED,
         Json(json!({

--- a/crates/sao-server/src/routes/bundle.rs
+++ b/crates/sao-server/src/routes/bundle.rs
@@ -1,6 +1,7 @@
 //! GET /api/agents/:id/bundle — packages a config.json + Tauri MSI installer for the user to
 //! run on their workstation. The config.json carries the entity's identity token and the
-//! anchor SAO URL. The MSI is read from one of three sources, in order:
+//! anchor SAO URL derived from the request host. deployment.json carries non-secret support
+//! metadata for the one-click installer flow. The MSI is read from one of three sources, in order:
 //!
 //!   1. The agent's pinned installer in the local cache
 //!      (`SAO_DATA_DIR/installers/<sha>/<filename>`). If the cache file is missing, SAO
@@ -11,15 +12,15 @@
 
 use std::io::{Cursor, Write};
 
+use axum::Json;
 use axum::{
     body::Body,
     extract::{Path, State},
-    http::{header, HeaderValue, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     response::Response,
     routing::get,
     Router,
 };
-use axum::Json;
 use serde_json::{json, Value};
 use uuid::Uuid;
 use zip::write::SimpleFileOptions;
@@ -39,26 +40,40 @@ const README_TEXT: &str = "OrionII entity bundle\n\
 =====================\n\
 \n\
 This ZIP contains:\n\
-  config.json            -- SAO base URL + entity identity token (the anchor).\n\
-  OrionII-Setup.msi      -- Tauri installer (Windows).\n\
+  config.json            -- SAO base URL, entity token, and OrionII bus transport intent.\n\
+  deployment.json        -- non-secret install manifest for support/debugging.\n\
+  OrionII-Setup.msi      -- Tauri installer (Windows, includes local nats-server sidecar).\n\
+  Install-OrionII.cmd    -- double-click installer launcher for Windows.\n\
+  Install-OrionII.ps1    -- helper used by the launcher.\n\
   README-FIRST-RUN.txt   -- this file.\n\
 \n\
 First run\n\
 ---------\n\
-1. Install: double-click OrionII-Setup.msi.\n\
-2. Drop config.json into:\n\
-       %APPDATA%\\OrionII\\config.json\n\
-   (the installer also accepts it co-located with OrionII.exe).\n\
-3. Launch OrionII. The app will:\n\
+1. Extract this ZIP.\n\
+2. Double-click Install-OrionII.cmd.\n\
+3. The launcher will copy config.json into %APPDATA%\\OrionII, run the MSI,\n\
+   update any existing OrionII install, and start OrionII. No JSON copy/paste is required.\n\
+   If someone accidentally double-clicks OrionII-Setup.msi directly from the\n\
+   extracted bundle, the MSI also self-enrolls from the sibling config.json.\n\
+4. OrionII will:\n\
      a. Read the SAO URL + entity token from config.json.\n\
      b. Call GET {sao_base_url}/api/orion/birth to dynamically receive the\n\
         live agent metadata, default provider/model, scopes, current policy,\n\
         and personality seed in a single response.\n\
-     c. Adopt the SAO-assigned identity and start chatting.\n\
+     c. Start OrionII's entity-internal EventBus. This bundle requests the\n\
+        packaged NATS JetStream transport for durable local topics; if the\n\
+        broker cannot start, OrionII falls back to its in-memory bus and stays alive.\n\
+     d. Adopt the SAO-assigned identity and start chatting.\n\
 \n\
 Because the runtime config is fetched live, changes the admin makes in SAO\n\
 (switching provider, swapping default model, updating policy) take effect on\n\
 the next OrionII launch -- no re-bundling required.\n\
+\n\
+Architecture note\n\
+-----------------\n\
+SAO does not participate in OrionII's internal bus. Mentor, Id, Ego, and local\n\
+Superego run inside OrionII and communicate by topic there. SAO remains the\n\
+external governance, birth, LLM-proxy, and sanitized-egress HTTP seam.\n\
 \n\
 Security\n\
 --------\n\
@@ -66,10 +81,108 @@ The agent_token is a long-lived bearer credential. Treat config.json like an\n\
 API key: do not share, do not commit. If lost, delete the agent in SAO and\n\
 download a new bundle (downloading also revokes any prior tokens for the agent).\n";
 
+const INSTALL_CMD: &str = "@echo off\r\n\
+setlocal\r\n\
+set SCRIPT_DIR=%~dp0\r\n\
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"%SCRIPT_DIR%Install-OrionII.ps1\"\r\n\
+if errorlevel 1 (\r\n\
+  echo.\r\n\
+  echo OrionII installation did not complete. Press any key to close this window.\r\n\
+  pause >nul\r\n\
+  exit /b 1\r\n\
+)\r\n";
+
+const INSTALL_PS1: &str = r#"$ErrorActionPreference = "Stop"
+
+$bundleDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$configSource = Join-Path $bundleDir "config.json"
+$deploymentSource = Join-Path $bundleDir "deployment.json"
+$msiPath = Join-Path $bundleDir "OrionII-Setup.msi"
+$configDir = Join-Path $env:APPDATA "OrionII"
+$configTarget = Join-Path $configDir "config.json"
+$deploymentTarget = Join-Path $configDir "deployment.json"
+
+if (-not (Test-Path $configSource)) {
+    throw "This bundle is missing config.json. Download a fresh OrionII bundle from SAO."
+}
+
+if (-not (Test-Path $msiPath)) {
+    throw "This bundle is missing OrionII-Setup.msi. Download a fresh OrionII bundle from SAO."
+}
+
+New-Item -ItemType Directory -Force -Path $configDir | Out-Null
+Copy-Item -Force $configSource $configTarget
+if (Test-Path $deploymentSource) {
+    Copy-Item -Force $deploymentSource $deploymentTarget
+}
+Write-Host "Saved OrionII enrollment config to $configTarget"
+
+if (Get-Process -Name "orionii" -ErrorAction SilentlyContinue) {
+    Write-Host "Closing running OrionII before install/update..."
+    Get-Process -Name "orionii" -ErrorAction SilentlyContinue | ForEach-Object {
+        try {
+            if ($_.MainWindowHandle -ne 0) {
+                [void]$_.CloseMainWindow()
+            }
+        }
+        catch {
+            # Best effort; force-stop below if the window did not close.
+        }
+    }
+    Start-Sleep -Seconds 2
+    Get-Process -Name "orionii" -ErrorAction SilentlyContinue | Stop-Process -Force
+}
+
+$uninstallRoots = @(
+    "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
+)
+$existingProducts = @(Get-ItemProperty $uninstallRoots -ErrorAction SilentlyContinue |
+    Where-Object { $_.DisplayName -eq "OrionII" -and $_.PSChildName -match "^\{[0-9A-Fa-f-]+\}$" })
+
+foreach ($product in $existingProducts) {
+    $version = if ($product.DisplayVersion) { $product.DisplayVersion } else { "unknown version" }
+    Write-Host "Removing existing OrionII $version before install/update..."
+    $remove = Start-Process -FilePath "msiexec.exe" `
+        -ArgumentList @("/x", $product.PSChildName, "/passive", "/norestart") `
+        -Wait `
+        -PassThru
+    if ($remove.ExitCode -notin @(0, 3010, 1605)) {
+        throw "Existing OrionII uninstall exited with code $($remove.ExitCode)."
+    }
+}
+
+Write-Host "Starting OrionII installer..."
+$installArgs = @("/i", "`"$msiPath`"", "/passive", "/norestart")
+$install = Start-Process -FilePath "msiexec.exe" -ArgumentList $installArgs -Wait -PassThru
+if ($install.ExitCode -notin @(0, 3010)) {
+    throw "OrionII installer exited with code $($install.ExitCode)."
+}
+if ($install.ExitCode -eq 3010) {
+    Write-Host "OrionII installed; Windows reported that a restart may be required."
+}
+
+$programRoots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+$candidates = $programRoots |
+    ForEach-Object { Join-Path $_ "OrionII\orionii.exe" } |
+    Where-Object { Test-Path $_ }
+
+if ($candidates.Count -gt 0) {
+    Write-Host "Launching OrionII..."
+    Start-Process -FilePath $candidates[0]
+}
+else {
+    Write-Host "OrionII installed. Launch it from the Start menu."
+}
+"#;
+
 async fn download_bundle(
     user: AuthUser,
     State(state): State<AppState>,
     axum::extract::Extension(context): axum::extract::Extension<RequestAuditContext>,
+    headers: HeaderMap,
     Path(id): Path<Uuid>,
 ) -> Result<Response, (StatusCode, Json<Value>)> {
     let agent = crate::db::agents::get_agent(&state.inner.db, id)
@@ -135,19 +248,24 @@ async fn download_bundle(
     .await
     .map_err(|e| internal(e.to_string()))?;
 
-    let sao_base_url = std::env::var("SAO_PUBLIC_BASE_URL")
-        .unwrap_or_else(|_| "http://localhost:3100".to_string());
+    let sao_base_url = public_base_url(&headers);
+    let bus_transport = json!({
+        "kind": "nats_jetstream",
+        "port": 4222,
+    });
 
     // Anchor-only: sao_base_url + agent_token are the minimum the entity needs to bootstrap.
     // Everything else (provider, models, policy, scopes, personality) comes from the live
     // GET /api/orion/birth call OrionII makes on every launch. The provider/model fields are
     // still embedded as a *fallback* for offline-from-SAO mode and for back-compat with
-    // older clients that don't yet call birth.
+    // older clients that don't yet call birth. bus_transport is OrionII-local intent only:
+    // SAO stays outside the entity bus and continues to interact over HTTP.
     let config = json!({
         "sao_base_url": sao_base_url,
         "agent_id": agent.id,
         "agent_token": minted.jwt,
         "client_version_min": "0.1.0",
+        "bus_transport": bus_transport,
         "fallback": {
             "default_provider": provider,
             "default_id_model": id_model,
@@ -157,8 +275,36 @@ async fn download_bundle(
         "default_id_model": id_model,
         "default_ego_model": ego_model,
     });
+    let deployment = json!({
+        "kind": "orionii.sao.deployment",
+        "schema_version": 1,
+        "downloaded_from": sao_base_url,
+        "agent_id": agent.id,
+        "installer": {
+            "file": "OrionII-Setup.msi",
+            "launcher": "Install-OrionII.cmd",
+        },
+        "runtime_config": {
+            "file": "config.json",
+            "target": "%APPDATA%\\OrionII\\config.json",
+            "contains_secret": true,
+        },
+        "bus_transport": bus_transport,
+        "sao_http_seam": {
+            "birth": "/api/orion/birth",
+            "llm": "/api/llm/generate",
+            "policy": "/api/orion/policy",
+            "egress": "/api/orion/egress",
+        },
+        "architecture": {
+            "orionii_hosts_entity_bus": true,
+            "sao_participates_in_entity_bus": false,
+            "note": "SAO remains external to OrionII's Mentor/Id/Ego/local Superego bus; the seam is HTTP only.",
+        }
+    });
 
-    let zip_bytes = build_zip(&config, &installer_bytes).map_err(|e| internal(e.to_string()))?;
+    let zip_bytes =
+        build_zip(&config, &deployment, &installer_bytes).map_err(|e| internal(e.to_string()))?;
 
     let _ = crate::db::audit::insert_audit_log(
         &state.inner.db,
@@ -171,6 +317,8 @@ async fn download_bundle(
             "token_jti": minted.jti,
             "token_expires_at": minted.expires_at,
             "revoked_prior_tokens": revoked,
+            "orion_bus_transport": "nats_jetstream",
+            "sao_base_url": sao_base_url,
             "request_id": context.request_id,
         })),
         context.client_ip.as_deref(),
@@ -200,7 +348,7 @@ async fn download_bundle(
     Ok(response)
 }
 
-fn build_zip(config: &Value, installer: &[u8]) -> std::io::Result<Vec<u8>> {
+fn build_zip(config: &Value, deployment: &Value, installer: &[u8]) -> std::io::Result<Vec<u8>> {
     let buffer = Cursor::new(Vec::new());
     let mut zip = zip::ZipWriter::new(buffer);
     let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
@@ -209,14 +357,60 @@ fn build_zip(config: &Value, installer: &[u8]) -> std::io::Result<Vec<u8>> {
     zip.start_file("config.json", opts)?;
     zip.write_all(&config_bytes)?;
 
+    let deployment_bytes = serde_json::to_vec_pretty(deployment)?;
+    zip.start_file("deployment.json", opts)?;
+    zip.write_all(&deployment_bytes)?;
+
     zip.start_file("OrionII-Setup.msi", opts)?;
     zip.write_all(installer)?;
+
+    zip.start_file("Install-OrionII.cmd", opts)?;
+    zip.write_all(INSTALL_CMD.as_bytes())?;
+
+    zip.start_file("Install-OrionII.ps1", opts)?;
+    zip.write_all(INSTALL_PS1.as_bytes())?;
 
     zip.start_file("README-FIRST-RUN.txt", opts)?;
     zip.write_all(README_TEXT.as_bytes())?;
 
     let cursor = zip.finish()?;
     Ok(cursor.into_inner())
+}
+
+fn public_base_url(headers: &HeaderMap) -> String {
+    request_base_url(headers)
+        .or_else(|| {
+            std::env::var("SAO_PUBLIC_BASE_URL")
+                .ok()
+                .map(|value| value.trim().trim_end_matches('/').to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or_else(|| "http://localhost:3100".to_string())
+}
+
+fn request_base_url(headers: &HeaderMap) -> Option<String> {
+    let host =
+        header_value(headers, "x-forwarded-host").or_else(|| header_value(headers, "host"))?;
+    let host = host.split(',').next()?.trim().trim_end_matches('/');
+    if host.is_empty() {
+        return None;
+    }
+
+    let proto = header_value(headers, "x-forwarded-proto")
+        .and_then(|value| value.split(',').next().map(str::trim).map(str::to_string))
+        .filter(|value| matches!(value.as_str(), "http" | "https"))
+        .unwrap_or_else(|| "http".to_string());
+
+    Some(format!("{proto}://{host}"))
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
 }
 
 fn internal(msg: String) -> (StatusCode, Json<Value>) {

--- a/crates/sao-server/src/routes/orion.rs
+++ b/crates/sao-server/src/routes/orion.rs
@@ -27,13 +27,8 @@ pub fn routes() -> Router<AppState> {
 /// `attribution_user()` to resolve a human owner regardless of which path matched.
 #[derive(Debug, Clone)]
 pub(crate) enum OrionBearerUser {
-    Entity {
-        agent_id: Uuid,
-        human_owner: Uuid,
-    },
-    User {
-        user_id: Uuid,
-    },
+    Entity { agent_id: Uuid, human_owner: Uuid },
+    User { user_id: Uuid },
 }
 
 impl OrionBearerUser {

--- a/crates/sao-server/tests/route_contracts.rs
+++ b/crates/sao-server/tests/route_contracts.rs
@@ -97,10 +97,42 @@ fn orion_routes_define_machine_policy_and_egress_contract() {
 }
 
 #[test]
+fn bundle_birth_and_llm_routes_define_entity_contracts() {
+    let bundle_src = include_str!("../src/routes/bundle.rs");
+    let orion_src = include_str!("../src/routes/orion.rs");
+    let llm_src = include_str!("../src/routes/llm.rs");
+
+    assert!(bundle_src.contains("/api/agents/:id/bundle"));
+    assert!(bundle_src.contains("\"sao_base_url\""));
+    assert!(bundle_src.contains("\"agent_token\""));
+    assert!(bundle_src.contains("\"bus_transport\""));
+    assert!(bundle_src.contains("\"nats_jetstream\""));
+    assert!(bundle_src.contains("deployment.json"));
+    assert!(bundle_src.contains("orionii.sao.deployment"));
+    assert!(bundle_src.contains("\"downloaded_from\""));
+    assert!(bundle_src.contains("Install-OrionII.cmd"));
+    assert!(bundle_src.contains("Install-OrionII.ps1"));
+    assert!(bundle_src.contains("public_base_url(&headers)"));
+    assert!(bundle_src.contains("x-forwarded-host"));
+    assert!(bundle_src.contains("GET /api/orion/birth"));
+    assert!(bundle_src.contains("SAO does not participate in OrionII's internal bus"));
+
+    assert!(orion_src.contains("/api/orion/birth"));
+    assert!(orion_src.contains("OrionBirthResponse"));
+    assert!(orion_src.contains("\"llm:generate\""));
+
+    assert!(llm_src.contains("/api/llm/generate"));
+    assert!(llm_src.contains("EntityCaller"));
+    assert!(llm_src.contains("validate_entity_token"));
+}
+
+#[test]
 fn security_keeps_orion_csrf_exception_scoped() {
     let src = include_str!("../src/security.rs");
     assert!(src.contains("is_orion_machine_request"));
     assert!(src.contains("\"/api/orion/egress\""));
+    assert!(src.contains("\"/api/orion/birth\""));
+    assert!(src.contains("\"/api/llm/generate\""));
     assert!(src.contains("requires_csrf(&method)"));
     assert!(src.contains("Bearer "));
 }

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # SAO ↔ OrionII — Project Status
 
-_Last updated: 2026-04-26_
+_Last updated: 2026-04-27_
 
 ## Where we are
 
@@ -44,8 +44,9 @@ Docker Compose stack with a real Anthropic upstream:
 
 ### User surface (`/agents`, `/agents/:id/events`)
 - Agent registration wizard: name + provider + Id model + Ego model.
-- Per-card **Download bundle** (mints fresh JWT, packages cached MSI + config.json + README)
-  and **Logs** (per-agent live egress feed, polls every 5s).
+- Per-card **Download bundle** (mints fresh JWT, packages cached MSI + config/deployment
+  manifests + one-click launcher + README) and **Logs** (per-agent live egress feed, polls every
+  5s).
 - Live `last_heartbeat` derived from the latest egress event.
 
 ### Runtime config — dynamic via birth event
@@ -54,8 +55,12 @@ Docker Compose stack with a real Anthropic upstream:
 - OrionII calls birth on every launch; the response overrides bundle defaults so admin
   changes (provider switch, model swap, policy update) take effect on the next OrionII boot
   with no re-bundling.
-- Bundle `config.json` is now an anchor (`sao_base_url` + `agent_token`); fallback fields
-  remain for offline mode.
+- Bundle `config.json` is now an anchor (`sao_base_url` + `agent_token`) plus OrionII-local
+  `bus_transport: { kind: "nats_jetstream", port: 4222 }`; fallback model fields remain for
+  offline mode. SAO derives `sao_base_url` from the bundle download host when possible, so users
+  do not edit JSON. The ZIP also includes `deployment.json` as a non-secret manifest of the
+  downloaded SAO origin, installer launcher, HTTP seam, and bus intent. SAO stays outside
+  OrionII's internal bus.
 
 ### OrionII desktop
 - Tauri 2 + React 19 shell. Boots in under a second.
@@ -64,8 +69,12 @@ Docker Compose stack with a real Anthropic upstream:
 - **In-app paste-config UI** — yellow "Enroll with SAO" panel visible until birth succeeds;
   pastes the JSON, validates, writes it to `%APPDATA%\OrionII\config.json`, hot-swaps the
   running OrionCore. No restart.
+- **One-click bundle install path** — downloaded bundles include `Install-OrionII.cmd`, which
+  writes `config.json`, runs the MSI, and starts OrionII for non-technical users.
 - Identity continuity preserved across reinstalls (durable JSON state file).
 - Egress payloads stamp `clientVersion` for fleet observability.
+- Chat egress now aligns with the OrionII topic design: `ego.action` produces a sanitized
+  `egress.outbound` audit event that SAO receives only through `POST /api/orion/egress`.
 
 ### Operational ergonomics
 - **Auto-unseal** — `SAO_VAULT_PASSPHRASE` env var unseals on startup so LLM keys stay
@@ -88,6 +97,9 @@ Docker Compose stack with a real Anthropic upstream:
 | `docker compose config` | ✅ validates |
 | Live e2e against Anthropic Haiku 4.5 | ✅ real Claude response in OrionII chat |
 
+For future OrionII internal transport changes, SAO-side seam regression can be exercised with
+`scripts/verify-orion-topic-shift.ps1` in either `-PrepareOnly` or full contract-exercise mode.
+
 ## What's open
 
 Tactical follow-ups (not blocking the loop):
@@ -100,7 +112,8 @@ Tactical follow-ups (not blocking the loop):
   on disk. Threat model is local desktop, but Stronghold/DPAPI is a defensible follow-up.
 - **GitHub Releases automation for the OrionII MSI** — workflow exists at
   [.github/workflows/release-installer.yml](https://github.com/jbcupps/OrionII/blob/main/.github/workflows/release-installer.yml);
-  needs a tag push to fire and produce assets the installer-sources registry can consume.
+  now packages the NATS JetStream sidecar by default, then a tag push produces assets the
+  installer-sources registry can consume.
 - **Deep-link enrollment** — `orion://enroll?token=...` URL handler so the bundle page can
   one-click enroll an installed OrionII without paste/file-drop.
 - **Tauri auto-updater** — install once, self-update against SAO. Needs Windows code signing

--- a/docs/orion-sao-mvp.md
+++ b/docs/orion-sao-mvp.md
@@ -3,12 +3,16 @@
 This document is the shared local MVP contract for wiring `C:\Repo\OrionII` to `C:\Repo\SAO`.
 SAO owns the control plane: identity, secrets, agent lifecycle, LLM key custody, and audit. OrionII
 owns the durable local desktop runtime: identity continuity, document indexing, and egress to SAO.
+This HTTP contract is the stable seam regardless of OrionII internals; swaps between in-process
+topics or durable-broker transport inside OrionII must preserve the paths, auth shape, and payloads
+described here. SAO does not participate in OrionII's entity-internal bus.
 
 ## MVP Scope
 
 - A signed-in SAO admin configures LLM provider keys (OpenAI / Anthropic / Ollama) once.
 - A signed-in SAO user creates an OrionII entity with a chosen provider + model.
-- The user downloads a bundle (`config.json` + `OrionII-Setup.msi`) from SAO.
+- The user downloads a one-click bundle (`config.json` + `deployment.json` +
+  `OrionII-Setup.msi` + install launcher) from SAO.
 - The downloaded entity adopts the SAO-assigned identity, phones home for policy, ships egress
   events, and routes all model calls through SAO's LLM proxy.
 - Browser setup remains installer-led; production bootstrap is the Azure conversational installer.
@@ -115,10 +119,32 @@ Errors:
 Mints a fresh entity JWT, revokes prior tokens for the same agent, packages a ZIP:
 
 ```
-config.json            -- sao_base_url, agent_id, agent_token (JWT), default models, client_version_min
+config.json            -- sao_base_url, agent_id, agent_token (JWT), bus_transport, defaults
+deployment.json        -- non-secret manifest: downloaded_from, installer file, HTTP seam, bus intent
 OrionII-Setup.msi      -- Tauri installer (read from SAO_ORION_INSTALLER_PATH inside the container)
+Install-OrionII.cmd    -- double-click Windows launcher that installs and writes config.json
+Install-OrionII.ps1    -- helper used by the launcher
 README-FIRST-RUN.txt   -- install steps
 ```
+
+The bundle's `config.json` requests OrionII's durable local bus transport while keeping SAO
+outside the bus:
+
+```json
+{
+  "sao_base_url": "http://localhost:3100",
+  "agent_id": "...",
+  "agent_token": "...",
+  "client_version_min": "0.1.0",
+  "bus_transport": { "kind": "nats_jetstream", "port": 4222 }
+}
+```
+
+`sao_base_url` is derived from the request host / forwarded host that served the bundle, falling
+back to `SAO_PUBLIC_BASE_URL` only when the request does not carry host information. This keeps
+downloads from a local container, LAN host, or reverse proxy pointed back at the same SAO origin
+without asking the user to edit JSON. `deployment.json.downloaded_from` records the same origin
+for support/debugging without duplicating the entity bearer token.
 
 Returns 503 if the installer is not staged with a clear remediation message.
 

--- a/docs/runbooks/local-orion-sao-mvp.md
+++ b/docs/runbooks/local-orion-sao-mvp.md
@@ -16,11 +16,18 @@ SAO's LLM proxy.
 ```powershell
 cd C:\Repo\OrionII
 npm ci
-npm run tauri build -- --bundles msi
+$env:ORIONII_NATS_SERVER = "C:\path\to\nats-server.exe"
+# or:
+# $env:ORIONII_NATS_SERVER_URL = "https://github.com/nats-io/nats-server/releases/download/v2.12.7/nats-server-v2.12.7-windows-amd64.zip"
+# $env:ORIONII_NATS_SERVER_SHA256 = "<expected-sha256>"
+npm run build:installer
 ```
 
 Output: `src-tauri/target/release/bundle/msi/OrionII_<version>_x64_en-US.msi`. SAO will fetch
-this from a URL you give it later — see step 4.
+this from a URL you give it later — see step 4. The build script prepares the bundled
+`nats-server` sidecar first, then builds the MSI with Tauri `externalBin` enabled for that
+release build. By default it downloads the official Windows NATS release ZIP; set
+`ORIONII_NATS_SERVER` or `ORIONII_NATS_SERVER_URL` to pin a local or hosted artifact.
 
 ## 2. Start SAO
 
@@ -124,25 +131,29 @@ The ZIP contains:
 
 | File | Purpose |
 |---|---|
-| `config.json` | SAO base URL + entity JWT (the anchor). Two extra fields are kept as
-fallback for offline mode + back-compat. |
+| `config.json` | SAO base URL + entity JWT (the anchor), plus `bus_transport` requesting OrionII's bundled NATS JetStream entity bus. Fallback model fields are kept for offline mode + back-compat. |
+| `deployment.json` | Non-secret manifest showing the SAO origin the bundle was downloaded from, installer file, HTTP seam, and bus intent. |
 | `OrionII-Setup.msi` | Tauri installer for Windows. |
+| `Install-OrionII.cmd` | Double-click launcher that writes `config.json`, runs the MSI, and starts OrionII. |
+| `Install-OrionII.ps1` | Helper used by the launcher. |
 | `README-FIRST-RUN.txt` | Install steps for the user. |
 
 ## 7. Install + run OrionII
 
-1. Run `OrionII-Setup.msi` and finish the install wizard.
-2. **Either** drop `config.json` into `%APPDATA%\OrionII\config.json`,
-   **or** launch OrionII first and paste the JSON into the yellow **Enroll with SAO** panel
-   that appears in the app — click **Apply config** and OrionII writes it for you and
-   hot-swaps the running core (no restart needed).
-3. The status card flips from `offline` → `birthed`, showing
+1. Extract the downloaded ZIP.
+2. Double-click `Install-OrionII.cmd`.
+3. Finish the MSI wizard if Windows prompts for confirmation. The launcher writes
+   `config.json` to `%APPDATA%\OrionII\config.json` automatically and starts OrionII.
+4. The status card flips from `offline` → `birthed`, showing
    `Birthed as <name> via <provider> (policy v1)` plus owner / id-model / ego-model.
 
 On launch:
 - Bootstrap reads `config.json` (sao_base_url + entity JWT).
 - Calls `GET /api/orion/birth` to fetch live agent metadata, endpoints, scopes, current
   policy, personality seed.
+- Starts OrionII's entity-internal EventBus. The SAO bundle requests `nats_jetstream`; if the
+  nats-server sidecar binary is not available yet, OrionII logs the issue and falls back to
+  `in_memory` so the entity remains usable.
 - Adopts the SAO-assigned `agent_id` as the local `orion_id`.
 - The model router is in `SaoProxyWithFallback` mode: every Id/Ego prompt POSTs to
   `/api/llm/generate` with `Authorization: Bearer <entity-JWT>`. Keys never leave SAO.
@@ -165,13 +176,25 @@ In OrionII:
 
 ## 9. Re-issue / revoke
 
-- **Re-download bundle** — revokes the old token and mints a new one. Re-paste the new
-  config.json (or drop it into `%APPDATA%\OrionII\` again).
+- **Re-download bundle** — revokes the old token and mints a new one. Extract it and
+  double-click `Install-OrionII.cmd` again; it overwrites `%APPDATA%\OrionII\config.json`
+  with the new token before launching OrionII.
 - **Delete the agent in SAO** — bulk-revokes all of its tokens. Subsequent `/api/orion/policy`
   / `/api/llm/generate` calls from the old install return 401.
 - **Roll the installer source forward** — register a new source with a new sha, set as
   default. New agents pin to the new sha; existing agents keep their original pin so they
   stay reproducible.
+
+## SAO-side seam verification
+
+When OrionII changes its internal transport but the SAO contract should stay stable, use
+`.\scripts\verify-orion-topic-shift.ps1` instead of relying on the smoke script alone.
+
+- `-PrepareOnly` creates a fresh agent + bundle + report for a manual two-window UAT pass.
+- default mode exercises `birth -> llm.generate -> egress` directly with the bundle's entity JWT.
+- `-RunRegressionChecks` adds token rotation, duplicate egress, restart continuity, and revocation.
+
+Full procedure: `docs/runbooks/verify-orion-topic-shift.md`.
 
 ## What lives where on disk (inside the container)
 
@@ -235,5 +258,5 @@ npm ci
 npm run build
 cargo test --manifest-path src-tauri\Cargo.toml --locked
 cargo clippy --manifest-path src-tauri\Cargo.toml --locked --all-targets -- -D warnings
-npm run tauri build -- --bundles msi
+npm run build:installer
 ```

--- a/docs/runbooks/verify-orion-topic-shift.md
+++ b/docs/runbooks/verify-orion-topic-shift.md
@@ -1,0 +1,177 @@
+# Verify OrionII Topic/Durable-Bus Shift From the SAO Side
+
+This runbook verifies that OrionII can change its internal transport
+(for example, from in-memory topics to NATS JetStream-backed topics) without breaking
+the SAO-facing seam.
+
+What this runbook proves:
+
+- SAO can still issue a bundle with the expected anchor fields.
+- The bundle includes `deployment.json` so the downloaded package records the SAO origin and
+  install intent without requiring a user to edit JSON.
+- The bundle includes a double-click installer launcher that writes `config.json` automatically.
+- The bundle requests OrionII's `nats_jetstream` bus transport without making SAO a bus participant.
+- The bundle still carries a valid entity JWT.
+- The entity JWT still works on `GET /api/orion/birth`,
+  `POST /api/llm/generate`, and `POST /api/orion/egress`.
+- SAO still persists egress, updates `last_heartbeat`, and records the
+  expected audit evidence.
+
+What this runbook does not prove on its own:
+
+- OrionII's internal topic graph is correct.
+- OrionII's bus subscribers are wired as intended.
+- OrionII's UI is showing the right state.
+
+Use it in one of two ways:
+
+1. `PrepareOnly` to create a fresh SAO verification subject for a manual
+   two-window UAT run with OrionII.
+2. Full contract exercise mode to simulate the OrionII seam from SAO by
+   extracting the bundle's entity JWT and calling the entity routes
+   directly.
+
+## Contract Invariants
+
+Treat `docs/orion-sao-mvp.md` as the shared contract. OrionII internal
+transport changes must preserve:
+
+- bundle `config.json` anchor fields plus `bus_transport.kind = nats_jetstream`
+- bundle install manifest + launcher entries: `deployment.json`, `Install-OrionII.cmd`, and
+  `Install-OrionII.ps1`
+- entity bearer auth on `/api/orion/*` and `/api/llm/generate`
+- current egress JSON shape
+- current event types: `identitySync`, `auditAction`, `memoryEvent`
+
+SAO is intentionally blind to OrionII's internal bus implementation. The
+verification surface here is the HTTP seam only.
+
+## Preflight
+
+Bring up SAO and confirm the local control plane is healthy before the
+verification run:
+
+```powershell
+cd C:\Repo\SAO
+.\scripts\local-mvp-smoke.ps1 -StartCompose
+```
+
+If you need the smoke flow to configure a local Ollama provider and prove
+bundle download before the seam verifier, use:
+
+```powershell
+cd C:\Repo\SAO
+.\scripts\local-mvp-smoke.ps1 -StartCompose -OllamaBaseUrl "http://host.docker.internal:11434" -OllamaModel "llama3.2"
+```
+
+The smoke script remains preflight only. It does not count as the
+milestone proof because it does not exercise the bundle's entity JWT on
+`birth -> llm -> egress`.
+
+## Manual Two-Window Verification
+
+Use this when OrionII is being driven in a separate window and SAO should
+only prepare the verification subject and observe evidence.
+
+```powershell
+cd C:\Repo\SAO
+.\scripts\verify-orion-topic-shift.ps1 `
+  -Provider "anthropic" `
+  -IdModel "claude-haiku-4-5-20251001" `
+  -EgoModel "claude-haiku-4-5-20251001" `
+  -PrepareOnly `
+  -OutputDir ".\artifacts"
+```
+
+The script will:
+
+- verify SAO health, setup mode, and vault state
+- confirm a default installer source exists
+- create a fresh agent
+- download a fresh bundle
+- extract `config.json`
+- extract `deployment.json`
+- record SAO commit, OrionII commit, agent id, installer sha/version,
+  provider, models, and bundle download time into `report.json`
+
+Then in the OrionII window:
+
+1. Install or launch the build under test.
+2. Extract the bundle and double-click `Install-OrionII.cmd`.
+3. Confirm the launcher installs OrionII, writes `%APPDATA%\OrionII\config.json`, and starts the app.
+4. Perform first launch / birth.
+5. Send one chat that should hit `POST /api/llm/generate`.
+6. Perform one action expected to emit egress after chat.
+
+While that happens, watch these SAO surfaces:
+
+- `/agents`
+- `/agents/:id/events`
+- `/api/admin/audit`
+- `docker compose -f docker\docker-compose.yml logs -f sao | Select-String "orion|llm"`
+
+Required evidence:
+
+- `agents.bundle_downloaded` audit row exists.
+- `orion.birth` audit row exists after OrionII launch.
+- `llm.generate` audit row exists and `llm.generate.failed` does not.
+- `/agents/:id/events` shows `identitySync` and at least one post-chat
+  event such as `auditAction` or `memoryEvent`.
+- `/api/agents/:id` shows a fresh `last_heartbeat`.
+
+## Automated SAO-Side Contract Exercise
+
+Use this when you want SAO to simulate the entity seam directly with the
+bundle's entity token.
+
+```powershell
+cd C:\Repo\SAO
+.\scripts\verify-orion-topic-shift.ps1 `
+  -Provider "anthropic" `
+  -IdModel "claude-haiku-4-5-20251001" `
+  -EgoModel "claude-haiku-4-5-20251001" `
+  -OutputDir ".\artifacts"
+```
+
+This mode:
+
+- prepares the same fresh agent and bundle
+- calls `GET /api/orion/birth` with the real entity JWT
+- calls `POST /api/llm/generate` with the real entity JWT
+- posts `identitySync` and `auditAction` egress with the real entity JWT
+- waits for `/api/agents/:id/events`, `/api/agents/:id`, and
+  `/api/admin/audit` to show the expected proof
+
+The generated `report.json` captures the exact coordinates and observed
+evidence for the run.
+
+## Optional Regression Checks
+
+Add `-RunRegressionChecks` to include:
+
+- repeated `birth` call for restart continuity
+- duplicate egress replay for idempotency
+- bundle re-download to prove old-token revocation and new-token success
+- agent deletion to prove entity-token revocation returns 401
+
+Example:
+
+```powershell
+cd C:\Repo\SAO
+.\scripts\verify-orion-topic-shift.ps1 `
+  -Provider "anthropic" `
+  -IdModel "claude-haiku-4-5-20251001" `
+  -EgoModel "claude-haiku-4-5-20251001" `
+  -RunRegressionChecks `
+  -OutputDir ".\artifacts"
+```
+
+## Failure Isolation
+
+- If bundle download fails, inspect installer pinning and staging first.
+- If bundle succeeds but `birth` fails, inspect token/config drift or
+  `/api/orion/birth` contract drift.
+- If `birth` and `llm` succeed but no egress appears, treat it as an
+  OrionII bus-to-egress subscriber problem, not a SAO problem.
+- If egress reaches SAO but is rejected or malformed, treat it as shared
+  contract drift and update both repos intentionally before retesting.

--- a/scripts/verify-orion-topic-shift.ps1
+++ b/scripts/verify-orion-topic-shift.ps1
@@ -1,0 +1,676 @@
+param(
+    [switch]$StartCompose,
+    [string]$BaseUrl = "http://localhost:3100",
+    [string]$PostgresPassword = "local-dev-only-change-me",
+    [string]$JwtSecret = "local-dev-only-change-me",
+    [string]$VaultPassphrase = "local-dev-only-change-me",
+    [string]$AdminUsername = "local-admin",
+    [string]$Provider = "",
+    [string]$IdModel = "",
+    [string]$EgoModel = "",
+    [string]$Prompt = "Reply with a short confirmation that the SAO seam is alive.",
+    [string]$SystemPrompt = "You are Orion's Ego layer participating in a verification run.",
+    [string]$AgentNamePrefix = "verify-orion",
+    [string]$OutputDir = "",
+    [switch]$PrepareOnly,
+    [switch]$RunRegressionChecks
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Write-Section {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "== $Message ==" -ForegroundColor Cyan
+}
+
+function Assert-Condition {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Wait-ForHealth {
+    param(
+        [string]$Url,
+        [int]$TimeoutSeconds = 90
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        try {
+            Invoke-RestMethod -Uri "$Url/api/health" -Method Get | Out-Null
+            return
+        }
+        catch {
+            if ((Get-Date) -gt $deadline) {
+                throw "SAO health endpoint did not become ready at $Url."
+            }
+            Start-Sleep -Seconds 3
+        }
+    } while ($true)
+}
+
+function Invoke-JsonRequest {
+    param(
+        [string]$Method,
+        [string]$Uri,
+        [hashtable]$Headers = @{},
+        [object]$Body = $null,
+        [string]$ContentType = "application/json"
+    )
+
+    $request = @{
+        Uri                = $Uri
+        Method             = $Method
+        Headers            = $Headers
+        SkipHttpErrorCheck = $true
+    }
+
+    if ($null -ne $Body) {
+        $request.Body = if ($Body -is [string]) { $Body } else { $Body | ConvertTo-Json -Depth 12 }
+        $request.ContentType = $ContentType
+    }
+
+    $response = Invoke-WebRequest @request
+    $rawBody = $response.Content
+    $jsonBody = $null
+
+    if ($rawBody) {
+        try {
+            $jsonBody = $rawBody | ConvertFrom-Json -AsHashtable
+        }
+        catch {
+            $jsonBody = $null
+        }
+    }
+
+    [pscustomobject]@{
+        StatusCode = [int]$response.StatusCode
+        RawBody    = $rawBody
+        JsonBody   = $jsonBody
+    }
+}
+
+function Download-File {
+    param(
+        [string]$Uri,
+        [hashtable]$Headers,
+        [string]$Destination
+    )
+
+    $response = Invoke-WebRequest -Uri $Uri -Headers $Headers -OutFile $Destination -SkipHttpErrorCheck -PassThru
+    $statusCode = if ($null -ne $response -and $null -ne $response.PSObject.Properties["StatusCode"]) {
+        [int]$response.StatusCode
+    }
+    elseif (Test-Path $Destination) {
+        200
+    }
+    else {
+        0
+    }
+
+    [pscustomobject]@{
+        StatusCode = $statusCode
+        Path       = $Destination
+        SizeBytes  = (Get-Item $Destination).Length
+    }
+}
+
+function Decode-Base64Url {
+    param([string]$Value)
+
+    $padded = $Value.Replace('-', '+').Replace('_', '/')
+    switch ($padded.Length % 4) {
+        2 { $padded += '==' }
+        3 { $padded += '=' }
+        0 { }
+        default { throw "Invalid base64url segment length." }
+    }
+
+    [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($padded))
+}
+
+function Read-JwtPayload {
+    param([string]$Jwt)
+
+    $parts = $Jwt.Split('.')
+    Assert-Condition ($parts.Length -eq 3) "Entity JWT did not have three segments."
+    (Decode-Base64Url $parts[1]) | ConvertFrom-Json -AsHashtable
+}
+
+function Read-ZipEntryText {
+    param(
+        [string]$ZipPath,
+        [string]$EntryName
+    )
+
+    Add-Type -AssemblyName System.IO.Compression
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+    try {
+        $entry = $zip.Entries | Where-Object { $_.FullName -eq $EntryName } | Select-Object -First 1
+        Assert-Condition ($null -ne $entry) "Bundle is missing $EntryName."
+
+        $stream = $entry.Open()
+        $reader = New-Object System.IO.StreamReader($stream)
+        try {
+            return $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+            $stream.Dispose()
+        }
+    }
+    finally {
+        $zip.Dispose()
+    }
+}
+
+function Get-GitCommit {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $null
+    }
+
+    $commit = git -C $Path rev-parse HEAD 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    $commit.Trim()
+}
+
+function Wait-ForAgentEvents {
+    param(
+        [string]$AgentId,
+        [hashtable]$Headers,
+        [string[]]$RequiredTypes,
+        [int]$TimeoutSeconds = 10
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $response = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/agents/$AgentId/events?limit=50&offset=0" -Headers $Headers
+        if ($response.StatusCode -eq 200) {
+            $events = @($response.JsonBody.events)
+            $types = @($events | ForEach-Object { $_.event_type })
+            $missing = @($RequiredTypes | Where-Object { $_ -notin $types })
+            if ($missing.Count -eq 0) {
+                return $events
+            }
+        }
+
+        if ((Get-Date) -gt $deadline) {
+            throw "Timed out waiting for agent events: $($RequiredTypes -join ', ')."
+        }
+
+        Start-Sleep -Seconds 1
+    } while ($true)
+}
+
+function Wait-ForAuditEntries {
+    param(
+        [string]$AgentId,
+        [hashtable]$Headers,
+        [string[]]$RequiredActions,
+        [int]$TimeoutSeconds = 10
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $response = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/admin/audit?limit=500&offset=0" -Headers $Headers
+        if ($response.StatusCode -eq 200) {
+            $entries = @($response.JsonBody.audit_log | Where-Object { $_.agent_id -eq $AgentId })
+            $actions = @($entries | ForEach-Object { $_.action })
+            $missing = @($RequiredActions | Where-Object { $_ -notin $actions })
+            if ($missing.Count -eq 0) {
+                return $entries
+            }
+        }
+
+        if ((Get-Date) -gt $deadline) {
+            throw "Timed out waiting for audit actions: $($RequiredActions -join ', ')."
+        }
+
+        Start-Sleep -Seconds 1
+    } while ($true)
+}
+
+function Get-AuditActionCount {
+    param(
+        [object[]]$Entries,
+        [string]$Action
+    )
+
+    @($Entries | Where-Object { $_.action -eq $Action }).Count
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$orionRepo = "C:\Repo\OrionII"
+$artifactRoot = if ($OutputDir) {
+    $OutputDir
+}
+else {
+    Join-Path ([System.IO.Path]::GetTempPath()) "sao-orion-verification"
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$runDir = Join-Path $artifactRoot "verify-orion-topic-shift-$timestamp"
+$reportPath = Join-Path $runDir "report.json"
+$bundlePath = Join-Path $runDir "bundle.zip"
+
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+$report = [ordered]@{
+    started_at   = (Get-Date).ToUniversalTime().ToString("o")
+    base_url     = $BaseUrl
+    mode         = if ($PrepareOnly) { "prepare-only" } else { "contract-exercise" }
+    run_regression_checks = [bool]$RunRegressionChecks
+    commits      = [ordered]@{
+        sao     = Get-GitCommit $repoRoot
+        orionii = Get-GitCommit $orionRepo
+    }
+    installer    = $null
+    provider     = $null
+    models       = $null
+    agent        = $null
+    bundle       = $null
+    happy_path   = $null
+    regressions  = $null
+    result       = "in_progress"
+}
+
+Push-Location $repoRoot
+try {
+    $env:POSTGRES_PASSWORD = $PostgresPassword
+    $env:SAO_JWT_SECRET = $JwtSecret
+    $env:SAO_LOCAL_BOOTSTRAP = "true"
+    $env:SAO_LOCAL_VAULT_PASSPHRASE = $VaultPassphrase
+    $env:SAO_LOCAL_ADMIN_USERNAME = $AdminUsername
+
+    if ($StartCompose) {
+        Write-Section "Starting Compose"
+        docker compose -f docker/docker-compose.yml up -d --build
+    }
+
+    Write-Section "Preflight"
+    Wait-ForHealth -Url $BaseUrl
+
+    docker compose -f docker/docker-compose.yml run --rm `
+        -e SAO_LOCAL_BOOTSTRAP=true `
+        -e SAO_LOCAL_VAULT_PASSPHRASE="$VaultPassphrase" `
+        -e SAO_LOCAL_ADMIN_USERNAME="$AdminUsername" `
+        sao sao-server bootstrap-local | Write-Host
+
+    $adminToken = docker compose -f docker/docker-compose.yml run --rm `
+        -e SAO_LOCAL_BOOTSTRAP=true `
+        -e SAO_LOCAL_ADMIN_USERNAME="$AdminUsername" `
+        sao sao-server mint-dev-token | Select-Object -Last 1
+
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($adminToken)) "Failed to mint local SAO bearer token."
+
+    $csrfToken = "verify-orion-$([guid]::NewGuid().ToString("N"))"
+    $adminHeaders = @{
+        Authorization  = "Bearer $adminToken"
+        Cookie         = "sao_csrf=$csrfToken"
+        "X-CSRF-Token" = $csrfToken
+    }
+
+    $health = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/health"
+    $setup = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/setup/status"
+    $vault = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/vault/status"
+
+    Assert-Condition ($health.StatusCode -eq 200) "Expected /api/health to return 200."
+    Assert-Condition ($setup.StatusCode -eq 200) "Expected /api/setup/status to return 200."
+    Assert-Condition ($setup.JsonBody.bootstrap_mode -eq "operational") "Expected bootstrap_mode=operational."
+    Assert-Condition ($vault.StatusCode -eq 200) "Expected /api/vault/status to return 200."
+    Assert-Condition ($vault.JsonBody.status -eq "unsealed") "Expected vault to be unsealed."
+
+    $providersResponse = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/admin/llm-providers" -Headers $adminHeaders
+    Assert-Condition ($providersResponse.StatusCode -eq 200) "Expected /api/admin/llm-providers to return 200."
+    $enabledProviders = @($providersResponse.JsonBody.providers | Where-Object { $_.enabled })
+    Assert-Condition ($enabledProviders.Count -gt 0) "No enabled LLM providers found in SAO."
+
+    $selectedProvider = $null
+    if ($Provider) {
+        $selectedProvider = $enabledProviders | Where-Object { $_.provider -eq $Provider } | Select-Object -First 1
+        Assert-Condition ($null -ne $selectedProvider) "Configured provider '$Provider' is not enabled in SAO."
+    }
+    elseif ($enabledProviders.Count -eq 1) {
+        $selectedProvider = $enabledProviders[0]
+    }
+    else {
+        throw "Multiple enabled providers were found. Pass -Provider to pin the verification run."
+    }
+
+    if (-not $IdModel) {
+        $IdModel = $selectedProvider.default_model
+    }
+    if (-not $EgoModel) {
+        $EgoModel = if ($IdModel) { $IdModel } else { $selectedProvider.default_model }
+    }
+
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($IdModel)) "Id model is required for the verification subject."
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($EgoModel)) "Ego model is required for the verification subject."
+
+    $installerResponse = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/admin/installer-sources" -Headers $adminHeaders
+    Assert-Condition ($installerResponse.StatusCode -eq 200) "Expected /api/admin/installer-sources to return 200."
+    $defaultInstaller = @($installerResponse.JsonBody.sources | Where-Object { $_.is_default }) | Select-Object -First 1
+    Assert-Condition ($null -ne $defaultInstaller) "No default OrionII installer source is registered in SAO."
+
+    $report.installer = [ordered]@{
+        id              = $defaultInstaller.id
+        filename        = $defaultInstaller.filename
+        version         = $defaultInstaller.version
+        expected_sha256 = $defaultInstaller.expected_sha256
+        url             = $defaultInstaller.url
+    }
+    $report.provider = $selectedProvider.provider
+    $report.models = [ordered]@{
+        id  = $IdModel
+        ego = $EgoModel
+    }
+
+    Write-Section "Creating Verification Agent"
+    $agentName = "$AgentNamePrefix-$([guid]::NewGuid().ToString().Substring(0, 8))"
+    $createAgentBody = @{
+        name              = $agentName
+        default_provider  = $selectedProvider.provider
+        default_id_model  = $IdModel
+        default_ego_model = $EgoModel
+    }
+
+    $createAgent = Invoke-JsonRequest -Method Post -Uri "$BaseUrl/api/agents" -Headers $adminHeaders -Body $createAgentBody
+    Assert-Condition ($createAgent.StatusCode -eq 201) "Expected /api/agents to return 201. Got $($createAgent.StatusCode)."
+
+    $agentId = $createAgent.JsonBody.agent_id
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($agentId)) "Agent creation did not return agent_id."
+
+    $report.agent = [ordered]@{
+        id   = $agentId
+        name = $agentName
+    }
+
+    Write-Section "Downloading Bundle"
+    $bundleDownload = Download-File -Uri "$BaseUrl/api/agents/$agentId/bundle" -Headers $adminHeaders -Destination $bundlePath
+    Assert-Condition ($bundleDownload.StatusCode -eq 200) "Expected /api/agents/$agentId/bundle to return 200. Got $($bundleDownload.StatusCode)."
+
+    $configJson = Read-ZipEntryText -ZipPath $bundlePath -EntryName "config.json"
+    $deploymentJson = Read-ZipEntryText -ZipPath $bundlePath -EntryName "deployment.json"
+    $installCmd = Read-ZipEntryText -ZipPath $bundlePath -EntryName "Install-OrionII.cmd"
+    $installPs1 = Read-ZipEntryText -ZipPath $bundlePath -EntryName "Install-OrionII.ps1"
+    $readme = Read-ZipEntryText -ZipPath $bundlePath -EntryName "README-FIRST-RUN.txt"
+    $config = $configJson | ConvertFrom-Json -AsHashtable
+    $deployment = $deploymentJson | ConvertFrom-Json -AsHashtable
+
+    Assert-Condition ($config.ContainsKey("sao_base_url")) "config.json is missing sao_base_url."
+    Assert-Condition ($config.ContainsKey("agent_token")) "config.json is missing agent_token."
+    Assert-Condition ($config.ContainsKey("agent_id")) "config.json is missing agent_id."
+    Assert-Condition ($config.ContainsKey("bus_transport")) "config.json is missing bus_transport."
+    Assert-Condition ($config.agent_id -eq $agentId) "config.json agent_id does not match the created agent."
+    Assert-Condition ($config.bus_transport.kind -eq "nats_jetstream") "config.json bus_transport.kind was not nats_jetstream."
+    Assert-Condition ($deployment.kind -eq "orionii.sao.deployment") "deployment.json kind did not match the OrionII deployment manifest."
+    Assert-Condition ($deployment.downloaded_from -eq $config.sao_base_url) "deployment.json downloaded_from did not match config sao_base_url."
+    Assert-Condition ($deployment.bus_transport.kind -eq "nats_jetstream") "deployment.json bus_transport.kind was not nats_jetstream."
+    Assert-Condition ($installCmd -match "Install-OrionII.ps1") "Install-OrionII.cmd does not launch the PowerShell helper."
+    Assert-Condition ($installPs1 -match "Copy-Item.*configSource.*configTarget") "Install-OrionII.ps1 does not copy config.json into APPDATA."
+    Assert-Condition ($installPs1 -match "Copy-Item.*deploymentSource.*deploymentTarget") "Install-OrionII.ps1 does not copy deployment.json into APPDATA."
+    Assert-Condition ($installPs1 -match 'Get-ItemProperty \$uninstallRoots') "Install-OrionII.ps1 does not detect existing OrionII MSI installs."
+    Assert-Condition ($installPs1 -match '"/x", \$product\.PSChildName') "Install-OrionII.ps1 does not uninstall stale OrionII before update."
+    Assert-Condition ($installPs1 -match '"/i", "`"\$msiPath`"", "/passive", "/norestart"') "Install-OrionII.ps1 does not install the bundled MSI after stale-product removal."
+    Assert-Condition ($installPs1 -match "Stop-Process -Force") "Install-OrionII.ps1 does not close stale running OrionII before update."
+    Assert-Condition ($readme -match "No JSON copy/paste is required") "README-FIRST-RUN.txt no longer promises no JSON copy/paste."
+    Assert-Condition ($readme -match "self-enrolls from the sibling config.json") "README-FIRST-RUN.txt does not document MSI self-enrollment."
+
+    $entityToken = $config.agent_token
+    $jwtClaims = Read-JwtPayload -Jwt $entityToken
+
+    Assert-Condition ($jwtClaims.sub -eq $agentId) "Entity JWT subject did not match the agent id."
+    Assert-Condition ($jwtClaims.entity_kind -eq "orion") "Entity JWT entity_kind was not 'orion'."
+    Assert-Condition ($jwtClaims.principal_type -eq "non_human") "Entity JWT principal_type was not 'non_human'."
+    Assert-Condition ($jwtClaims.scope -match "orion:policy") "Entity JWT scope is missing orion:policy."
+    Assert-Condition ($jwtClaims.scope -match "orion:egress") "Entity JWT scope is missing orion:egress."
+    Assert-Condition ($jwtClaims.scope -match "llm:generate") "Entity JWT scope is missing llm:generate."
+
+    $report.bundle = [ordered]@{
+        downloaded_at = (Get-Date).ToUniversalTime().ToString("o")
+        zip_path      = $bundlePath
+        size_bytes    = $bundleDownload.SizeBytes
+        install_launcher = [ordered]@{
+            cmd_present = $true
+            ps1_present = $true
+        }
+        deployment     = [ordered]@{
+            kind            = $deployment.kind
+            downloaded_from = $deployment.downloaded_from
+            bus_transport   = $deployment.bus_transport
+        }
+        config        = [ordered]@{
+            sao_base_url        = $config.sao_base_url
+            agent_id            = $config.agent_id
+            client_version_min  = $config.client_version_min
+            default_provider    = $config.default_provider
+            default_id_model    = $config.default_id_model
+            default_ego_model   = $config.default_ego_model
+            bus_transport       = $config.bus_transport
+            fallback            = $config.fallback
+        }
+        jwt_claims = $jwtClaims
+    }
+
+    if ($PrepareOnly) {
+        $report.result = "prepared"
+        $report | ConvertTo-Json -Depth 12 | Set-Content -Path $reportPath
+
+        Write-Section "Prepared"
+        Write-Host "Verification subject is ready."
+        Write-Host "Agent ID: $agentId"
+        Write-Host "Bundle:   $bundlePath"
+        Write-Host "Report:   $reportPath"
+        Write-Host ""
+        Write-Host "Next step: launch OrionII with this bundle in the other window, then watch /agents, /agents/$agentId/events, and /api/admin/audit in SAO."
+        return
+    }
+
+    $entityHeaders = @{ Authorization = "Bearer $entityToken" }
+    $orionId = $agentId
+    $happyPath = [ordered]@{}
+
+    Write-Section "Exercising Entity Contract"
+    $birth = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/orion/birth" -Headers $entityHeaders
+    Assert-Condition ($birth.StatusCode -eq 200) "Expected /api/orion/birth to return 200. Got $($birth.StatusCode)."
+    Assert-Condition ($birth.JsonBody.agent.id -eq $agentId) "Birth response agent id did not match the created agent."
+    Assert-Condition ($birth.JsonBody.endpoints.egressUrl -eq "/api/orion/egress") "Birth response egressUrl drifted."
+    Assert-Condition ($birth.JsonBody.endpoints.birthUrl -eq "/api/orion/birth") "Birth response birthUrl drifted."
+    Assert-Condition ($birth.JsonBody.endpoints.llmUrl -eq "/api/llm/generate") "Birth response llmUrl drifted."
+
+    $happyPath.birth = [ordered]@{
+        status_code = $birth.StatusCode
+        birthed_at  = $birth.JsonBody.birthedAt
+    }
+
+    $llmRequest = @{
+        provider    = $selectedProvider.provider
+        model       = $EgoModel
+        system      = $SystemPrompt
+        prompt      = $Prompt
+        temperature = 0.2
+        role        = "ego"
+    }
+    $llm = Invoke-JsonRequest -Method Post -Uri "$BaseUrl/api/llm/generate" -Headers $entityHeaders -Body $llmRequest
+    Assert-Condition ($llm.StatusCode -eq 200) "Expected /api/llm/generate to return 200. Got $($llm.StatusCode)."
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($llm.JsonBody.text)) "LLM response text was empty."
+
+    $llmLatencyMs = if ($llm.JsonBody.ContainsKey("latencyMs")) {
+        $llm.JsonBody.latencyMs
+    }
+    else {
+        $llm.JsonBody.latency_ms
+    }
+
+    $happyPath.llm = [ordered]@{
+        status_code = $llm.StatusCode
+        provider    = $selectedProvider.provider
+        model       = $llm.JsonBody.model
+        latency_ms  = $llmLatencyMs
+    }
+
+    $identityEventId = [guid]::NewGuid()
+    $auditEventId = [guid]::NewGuid()
+    $correlationId = [guid]::NewGuid()
+    $egressRequest = @{
+        agentId       = $agentId
+        orionId       = $orionId
+        clientVersion = $config.client_version_min
+        events        = @(
+            @{
+                id         = $identityEventId
+                enqueuedAt = (Get-Date).ToUniversalTime().ToString("o")
+                attempts   = 1
+                event      = @{
+                    identitySync = @{
+                        orionId = $orionId
+                        version = 1
+                    }
+                }
+            },
+            @{
+                id         = $auditEventId
+                enqueuedAt = (Get-Date).ToUniversalTime().ToString("o")
+                attempts   = 1
+                event      = @{
+                    auditAction = @{
+                        action        = "verify-orion-topic-shift"
+                        correlationId = $correlationId
+                    }
+                }
+            }
+        )
+    }
+    $egress = Invoke-JsonRequest -Method Post -Uri "$BaseUrl/api/orion/egress" -Headers $entityHeaders -Body $egressRequest
+    Assert-Condition ($egress.StatusCode -eq 200) "Expected /api/orion/egress to return 200. Got $($egress.StatusCode)."
+    Assert-Condition ($egress.JsonBody.accepted -ge 2) "Expected both egress events to be accepted."
+
+    $events = Wait-ForAgentEvents -AgentId $agentId -Headers $adminHeaders -RequiredTypes @("identitySync", "auditAction")
+    $agentStatus = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/agents/$agentId" -Headers $adminHeaders
+    Assert-Condition ($agentStatus.StatusCode -eq 200) "Expected /api/agents/$agentId to return 200."
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($agentStatus.JsonBody.last_heartbeat)) "Expected last_heartbeat after egress."
+
+    $auditEntries = Wait-ForAuditEntries -AgentId $agentId -Headers $adminHeaders -RequiredActions @(
+        "agents.bundle_downloaded",
+        "orion.birth",
+        "llm.generate",
+        "orion.egress"
+    )
+    $llmFailures = Get-AuditActionCount -Entries $auditEntries -Action "llm.generate.failed"
+    Assert-Condition ($llmFailures -eq 0) "Found llm.generate.failed audit rows during the happy path."
+
+    $happyPath.egress = [ordered]@{
+        status_code   = $egress.StatusCode
+        accepted      = $egress.JsonBody.accepted
+        duplicate     = $egress.JsonBody.duplicate
+        event_types   = @($events | ForEach-Object { $_.event_type } | Select-Object -Unique)
+        last_heartbeat = $agentStatus.JsonBody.last_heartbeat
+    }
+    $happyPath.audit = [ordered]@{
+        bundle_downloaded = Get-AuditActionCount -Entries $auditEntries -Action "agents.bundle_downloaded"
+        birth             = Get-AuditActionCount -Entries $auditEntries -Action "orion.birth"
+        llm_generate      = Get-AuditActionCount -Entries $auditEntries -Action "llm.generate"
+        llm_failed        = $llmFailures
+        orion_egress      = Get-AuditActionCount -Entries $auditEntries -Action "orion.egress"
+    }
+
+    $report.happy_path = $happyPath
+
+    if ($RunRegressionChecks) {
+        Write-Section "Running Regression Checks"
+        $regressions = [ordered]@{}
+
+        $restartBirth = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/orion/birth" -Headers $entityHeaders
+        Assert-Condition ($restartBirth.StatusCode -eq 200) "Expected repeated /api/orion/birth to succeed before token rotation."
+        $regressions.restart_continuity = [ordered]@{
+            repeated_birth_status = $restartBirth.StatusCode
+        }
+
+        $duplicateEgress = Invoke-JsonRequest -Method Post -Uri "$BaseUrl/api/orion/egress" -Headers $entityHeaders -Body @{
+            agentId       = $agentId
+            orionId       = $orionId
+            clientVersion = $config.client_version_min
+            events        = @(
+                @{
+                    id         = $identityEventId
+                    enqueuedAt = (Get-Date).ToUniversalTime().ToString("o")
+                    attempts   = 2
+                    event      = @{
+                        identitySync = @{
+                            orionId = $orionId
+                            version = 1
+                        }
+                    }
+                }
+            )
+        }
+        Assert-Condition ($duplicateEgress.StatusCode -eq 200) "Expected duplicate /api/orion/egress call to return 200."
+        Assert-Condition ($duplicateEgress.JsonBody.duplicate -ge 1) "Expected duplicate egress to be acknowledged as duplicate."
+        $regressions.idempotency = [ordered]@{
+            status_code = $duplicateEgress.StatusCode
+            duplicate   = $duplicateEgress.JsonBody.duplicate
+        }
+
+        $rotatedBundlePath = Join-Path $runDir "bundle-rotated.zip"
+        $rotatedDownload = Download-File -Uri "$BaseUrl/api/agents/$agentId/bundle" -Headers $adminHeaders -Destination $rotatedBundlePath
+        Assert-Condition ($rotatedDownload.StatusCode -eq 200) "Expected rotated bundle download to return 200."
+        $rotatedConfig = (Read-ZipEntryText -ZipPath $rotatedBundlePath -EntryName "config.json") | ConvertFrom-Json -AsHashtable
+        $newEntityToken = $rotatedConfig.agent_token
+
+        $oldBirthAfterRotation = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/orion/birth" -Headers @{ Authorization = "Bearer $entityToken" }
+        $newBirthAfterRotation = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/orion/birth" -Headers @{ Authorization = "Bearer $newEntityToken" }
+        Assert-Condition ($oldBirthAfterRotation.StatusCode -eq 401) "Expected the old entity token to fail after bundle rotation."
+        Assert-Condition ($newBirthAfterRotation.StatusCode -eq 200) "Expected the new entity token to succeed after bundle rotation."
+        $regressions.token_rotation = [ordered]@{
+            old_token_birth_status = $oldBirthAfterRotation.StatusCode
+            new_token_birth_status = $newBirthAfterRotation.StatusCode
+        }
+
+        $deleteAgent = Invoke-JsonRequest -Method Post -Uri "$BaseUrl/api/agents/$agentId/delete" -Headers $adminHeaders
+        Assert-Condition ($deleteAgent.StatusCode -eq 200) "Expected agent deletion to return 200."
+        $birthAfterDelete = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/orion/birth" -Headers @{ Authorization = "Bearer $newEntityToken" }
+        Assert-Condition ($birthAfterDelete.StatusCode -eq 401) "Expected entity token to be revoked after agent deletion."
+        $regressions.revocation = [ordered]@{
+            delete_status      = $deleteAgent.StatusCode
+            revoked_birth_code = $birthAfterDelete.StatusCode
+        }
+
+        $report.regressions = $regressions
+    }
+
+    $report.result = "passed"
+    $report.completed_at = (Get-Date).ToUniversalTime().ToString("o")
+    $report | ConvertTo-Json -Depth 12 | Set-Content -Path $reportPath
+
+    Write-Section "Verification Passed"
+    Write-Host "Agent ID: $agentId"
+    Write-Host "Provider: $($selectedProvider.provider)"
+    Write-Host "Models:   id=$IdModel ego=$EgoModel"
+    Write-Host "Bundle:   $bundlePath"
+    Write-Host "Report:   $reportPath"
+}
+catch {
+    $report.result = "failed"
+    $report.error = $_.Exception.Message
+    $report.failed_at = (Get-Date).ToUniversalTime().ToString("o")
+    $report | ConvertTo-Json -Depth 12 | Set-Content -Path $reportPath
+    throw
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

Ships the SAO side of the coordinated OrionII MVP: downloaded agent bundles now provide a non-technical one-click OrionII install/enrollment flow and carry the durable bus transport intent needed by OrionII.

## What changed

- Adds `config.json` + `deployment.json` bundle metadata with `bus_transport: { kind: "nats_jetstream", port: 4222 }`.
- Adds `Install-OrionII.cmd` and `Install-OrionII.ps1` to the downloaded bundle so users do not paste JSON.
- Hardens the installer helper to close stale OrionII, uninstall prior MSI installs, install the bundled MSI fresh, and preserve `%APPDATA%\OrionII\config.json`.
- Adds installer source registry and cache handling needed to serve the packaged OrionII MSI.
- Tightens agent token/revocation behavior and route contracts for birth, LLM proxy, egress, bundle download, and installer management.
- Adds `scripts/verify-orion-topic-shift.ps1` plus a runbook for repeatable joint UAT.

## Validation

- `cargo check -p sao-server`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Frontend `npm run build`
- Frontend `npm test`
- `./scripts/verify-orion-topic-shift.ps1 -RunRegressionChecks`

Latest local verification passed with:

- Installer: `OrionII_0.1.1_x64_en-US.msi`
- SHA256: `39b5e3f1821f7d74b3c151137881382e1dadf357a981c64e4383dbf53a315081`
- Birth: `200`
- LLM: `200`
- Egress accepted: `2`
- Token rotation old/new: `401` / `200`
- Revocation: `401`

## Paired Work

Pairs with OrionII PR: https://github.com/jbcupps/OrionII/pull/4
