### PR TITLE
feat(agents): derive presence from last egress and surface in admin UI

### DIFF
--- a/crates/sao-server/src/db/agents.rs
+++ b/crates/sao-server/src/db/agents.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -123,6 +125,42 @@ pub async fn last_egress_at(
             .fetch_optional(pool)
             .await?;
     Ok(row.and_then(|r| r.0))
+}
+
+/// Batched companion to `last_egress_at` for the agents-list endpoint.
+/// Returns a map keyed by `agent_id` with the most recent `created_at` from
+/// `orion_egress_events`. Agents with no rows are absent from the map.
+pub async fn last_egress_at_for_many(
+    pool: &PgPool,
+    agent_ids: &[Uuid],
+) -> Result<HashMap<Uuid, chrono::DateTime<chrono::Utc>>, sqlx::Error> {
+    if agent_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let rows: Vec<(Uuid, Option<chrono::DateTime<chrono::Utc>>)> = sqlx::query_as(
+        "SELECT agent_id, MAX(created_at) FROM orion_egress_events \
+         WHERE agent_id = ANY($1) GROUP BY agent_id",
+    )
+    .bind(agent_ids)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|(id, ts)| ts.map(|t| (id, t)))
+        .collect())
+}
+
+/// Online if the agent shipped egress within the last 5 minutes; otherwise Offline.
+/// Presence is derived purely from observed egress activity — there is no separate
+/// heartbeat protocol — so a parked cockpit lapses to Offline correctly.
+pub fn presence_from_last_seen(
+    now: chrono::DateTime<chrono::Utc>,
+    last_seen: Option<chrono::DateTime<chrono::Utc>>,
+) -> &'static str {
+    match last_seen {
+        Some(t) if now.signed_duration_since(t) < chrono::Duration::minutes(5) => "online",
+        _ => "offline",
+    }
 }
 
 pub async fn delete_agent(pool: &PgPool, id: Uuid) -> Result<bool, sqlx::Error> {

--- a/crates/sao-server/src/routes/agents.rs
+++ b/crates/sao-server/src/routes/agents.rs
@@ -4,8 +4,8 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use chrono::Utc;
-use serde::Deserialize;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs;
 use uuid::Uuid;
@@ -125,19 +125,53 @@ async fn validate_agent_llm_defaults(
     })
 }
 
+/// Serialization wrapper that adds the M2 presence fields onto the raw `AgentRow`.
+/// `AgentRow` stays a pure DB-shape; route enrichment lives here.
+#[derive(Serialize)]
+struct AgentListItem {
+    #[serde(flatten)]
+    row: crate::db::agents::AgentRow,
+    last_seen_at: Option<DateTime<Utc>>,
+    presence: &'static str,
+}
+
 async fn list_agents(user: AuthUser, State(state): State<AppState>) -> (StatusCode, Json<Value>) {
     let owner_filter = if user.is_admin() {
         None
     } else {
         Some(user.user_id)
     };
-    match crate::db::agents::list_agents(&state.inner.db, owner_filter).await {
-        Ok(agents) => (StatusCode::OK, Json(json!({ "agents": agents }))),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": e.to_string() })),
-        ),
-    }
+    let rows = match crate::db::agents::list_agents(&state.inner.db, owner_filter).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+
+    let ids: Vec<Uuid> = rows.iter().map(|row| row.id).collect();
+    // Best-effort: if the egress query fails, surface agents with `presence: "offline"`
+    // rather than 500ing the whole list.
+    let last_seen_map = crate::db::agents::last_egress_at_for_many(&state.inner.db, &ids)
+        .await
+        .unwrap_or_default();
+    let now = Utc::now();
+    let agents: Vec<AgentListItem> = rows
+        .into_iter()
+        .map(|row| {
+            let last_seen_at = last_seen_map.get(&row.id).copied();
+            let presence = crate::db::agents::presence_from_last_seen(now, last_seen_at);
+            AgentListItem {
+                row,
+                last_seen_at,
+                presence,
+            }
+        })
+        .collect();
+
+    (StatusCode::OK, Json(json!({ "agents": agents })))
 }
 
 #[derive(Deserialize)]
@@ -336,10 +370,11 @@ async fn get_agent_status(
         );
     }
 
-    let last_heartbeat = crate::db::agents::last_egress_at(&state.inner.db, id)
+    let last_seen_at = crate::db::agents::last_egress_at(&state.inner.db, id)
         .await
         .ok()
         .flatten();
+    let presence = crate::db::agents::presence_from_last_seen(Utc::now(), last_seen_at);
     let available_llm_providers = crate::db::llm_providers::list_enabled_catalog(&state.inner.db)
         .await
         .unwrap_or_default();
@@ -358,7 +393,8 @@ async fn get_agent_status(
             "default_id_model": agent.default_id_model,
             "default_ego_model": agent.default_ego_model,
             "available_llm_providers": available_llm_providers,
-            "last_heartbeat": last_heartbeat,
+            "last_seen_at": last_seen_at,
+            "presence": presence,
         })),
     )
 }
@@ -441,10 +477,11 @@ async fn update_agent_handler(
         }
     };
 
-    let last_heartbeat = crate::db::agents::last_egress_at(&state.inner.db, id)
+    let last_seen_at = crate::db::agents::last_egress_at(&state.inner.db, id)
         .await
         .ok()
         .flatten();
+    let presence = crate::db::agents::presence_from_last_seen(Utc::now(), last_seen_at);
     let available_llm_providers = crate::db::llm_providers::list_enabled_catalog(&state.inner.db)
         .await
         .unwrap_or_default();
@@ -481,7 +518,8 @@ async fn update_agent_handler(
             "default_id_model": updated.default_id_model,
             "default_ego_model": updated.default_ego_model,
             "available_llm_providers": available_llm_providers,
-            "last_heartbeat": last_heartbeat,
+            "last_seen_at": last_seen_at,
+            "presence": presence,
         })),
     )
 }

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -47,7 +47,7 @@ Docker Compose stack with a real Anthropic upstream:
 - Per-card **Download bundle** (mints fresh JWT, packages cached MSI + config/deployment
   manifests + one-click launcher + README) and **Logs** (per-agent live egress feed, polls every
   5s).
-- Live `last_heartbeat` derived from the latest egress event.
+- Live `last_seen_at` + derived `presence` (online/offline) computed from the latest egress event.
 
 ### Runtime config — dynamic via birth event
 - `GET /api/orion/birth` returns one rich payload: agent metadata, endpoint URLs, owner,

--- a/docs/runbooks/verify-orion-topic-shift.md
+++ b/docs/runbooks/verify-orion-topic-shift.md
@@ -14,8 +14,8 @@ What this runbook proves:
 - The bundle still carries a valid entity JWT.
 - The entity JWT still works on `GET /api/orion/birth`,
   `POST /api/llm/generate`, and `POST /api/orion/egress`.
-- SAO still persists egress, updates `last_heartbeat`, and records the
-  expected audit evidence.
+- SAO still persists egress, updates `last_seen_at` (and the derived
+  `presence` flag), and records the expected audit evidence.
 
 What this runbook does not prove on its own:
 
@@ -117,7 +117,7 @@ Required evidence:
 - `llm.generate` audit row exists and `llm.generate.failed` does not.
 - `/agents/:id/events` shows `identitySync` and at least one post-chat
   event such as `auditAction` or `memoryEvent`.
-- `/api/agents/:id` shows a fresh `last_heartbeat`.
+- `/api/agents/:id` shows a fresh `last_seen_at` and `presence: "online"`.
 
 ## Automated SAO-Side Contract Exercise
 

--- a/frontend/src/lib/time-format.ts
+++ b/frontend/src/lib/time-format.ts
@@ -1,0 +1,30 @@
+/**
+ * Render a timestamp as a relative phrase ("12 seconds ago", "in 3 hours").
+ * Returns "never seen" for null/undefined/invalid input so callers can
+ * surface "agent has no egress yet" without a separate branch.
+ *
+ * Buckets:
+ *   < 60s     → seconds
+ *   < 60m     → minutes
+ *   < 24h     → hours
+ *   otherwise → days
+ *
+ * The `now` parameter exists so unit tests can control the reference clock.
+ */
+export function formatRelativeTime(
+  iso: string | null | undefined,
+  now: Date = new Date(),
+): string {
+  if (!iso) return 'never seen';
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return 'never seen';
+
+  const diffSec = Math.round((then.getTime() - now.getTime()) / 1000);
+  const fmt = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+  const abs = Math.abs(diffSec);
+
+  if (abs < 60) return fmt.format(diffSec, 'second');
+  if (abs < 3600) return fmt.format(Math.round(diffSec / 60), 'minute');
+  if (abs < 86_400) return fmt.format(Math.round(diffSec / 3600), 'hour');
+  return fmt.format(Math.round(diffSec / 86_400), 'day');
+}

--- a/frontend/src/pages/AgentEventsPage.tsx
+++ b/frontend/src/pages/AgentEventsPage.tsx
@@ -97,9 +97,9 @@ export default function AgentEventsPage() {
           <h1 className="text-2xl font-bold text-white">
             Events — {agent ? agent.agent_id.slice(0, 8) : id.slice(0, 8)}
           </h1>
-          {agent?.last_heartbeat && (
+          {agent?.last_seen_at && (
             <p className="text-xs text-gray-400 mt-1">
-              Last heartbeat: {new Date(agent.last_heartbeat).toLocaleString()}
+              Last seen: {new Date(agent.last_seen_at).toLocaleString()}
             </p>
           )}
         </div>

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -10,9 +10,11 @@ import {
 import { listAvailableLlmProviders } from '../api/llm-providers';
 import { AgentLlmFields, buildAgentLlmSelection } from '../components/AgentLlmFields';
 import { listAgents } from '../api/agents';
+import { formatRelativeTime } from '../lib/time-format';
 import type {
   Agent,
   AgentLlmProviderOption,
+  AgentPresence,
   AgentStatusResponse,
 } from '../types';
 
@@ -39,6 +41,9 @@ export default function AgentsPage() {
   const { data: agents, isLoading } = useQuery({
     queryKey: ['agents'],
     queryFn: listAgents,
+    // Re-poll every 30s so the presence dot reflects recent egress activity
+    // without forcing the operator to manually refresh the page.
+    refetchInterval: 30_000,
   });
 
   const { data: providers, isLoading: providersLoading } = useQuery({
@@ -138,20 +143,8 @@ export default function AgentsPage() {
     queryClient.setQueryData(['agent', agentId], updated);
   };
 
-  const stateColor = (state: string) => {
-    switch (state) {
-      case 'active':
-      case 'online':
-        return 'bg-green-500';
-      case 'inactive':
-      case 'offline':
-        return 'bg-gray-500';
-      case 'error':
-        return 'bg-red-500';
-      default:
-        return 'bg-yellow-500';
-    }
-  };
+  const presenceColor = (presence?: AgentPresence) =>
+    presence === 'online' ? 'bg-green-500' : 'bg-gray-500';
 
   return (
     <div>
@@ -252,10 +245,15 @@ export default function AgentsPage() {
                 <div>
                   <h3 className="text-white font-semibold">{agent.name}</h3>
                   <p className="text-xs text-gray-500 font-mono mt-0.5">{agent.id}</p>
+                  <p className="text-xs text-gray-500 mt-1">
+                    {formatRelativeTime(agent.last_seen_at)}
+                  </p>
                 </div>
                 <div className="flex items-center gap-1.5">
-                  <span className={`w-2.5 h-2.5 rounded-full ${stateColor(agent.state)}`} />
-                  <span className="text-xs text-gray-400 capitalize">{agent.state}</span>
+                  <span className={`w-2.5 h-2.5 rounded-full ${presenceColor(agent.presence)}`} />
+                  <span className="text-xs text-gray-400 capitalize">
+                    {agent.presence ?? 'offline'}
+                  </span>
                 </div>
               </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,8 @@ export interface VaultSecret {
   updated_at: string;
 }
 
+export type AgentPresence = 'online' | 'offline';
+
 export interface Agent {
   id: string;
   name: string;
@@ -31,6 +33,10 @@ export interface Agent {
   default_provider?: string | null;
   default_id_model?: string | null;
   default_ego_model?: string | null;
+  /** ISO timestamp of the agent's most recent egress event; null if never seen. */
+  last_seen_at?: string | null;
+  /** Derived presence: online if last_seen_at within 5 min, else offline. */
+  presence?: AgentPresence;
 }
 
 export interface AgentLlmProviderOption {
@@ -134,7 +140,10 @@ export interface AgentStatusResponse {
   default_id_model?: string | null;
   default_ego_model?: string | null;
   available_llm_providers?: AgentLlmProviderOption[];
-  last_heartbeat?: string | null;
+  /** ISO timestamp of the agent's most recent egress event; null if never seen. */
+  last_seen_at?: string | null;
+  /** Derived presence: online if last_seen_at within 5 min, else offline. */
+  presence?: AgentPresence;
 }
 
 export interface OidcProvider {

--- a/scripts/verify-orion-topic-shift.ps1
+++ b/scripts/verify-orion-topic-shift.ps1
@@ -565,7 +565,8 @@ try {
     $events = Wait-ForAgentEvents -AgentId $agentId -Headers $adminHeaders -RequiredTypes @("identitySync", "auditAction")
     $agentStatus = Invoke-JsonRequest -Method Get -Uri "$BaseUrl/api/agents/$agentId" -Headers $adminHeaders
     Assert-Condition ($agentStatus.StatusCode -eq 200) "Expected /api/agents/$agentId to return 200."
-    Assert-Condition (-not [string]::IsNullOrWhiteSpace($agentStatus.JsonBody.last_heartbeat)) "Expected last_heartbeat after egress."
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($agentStatus.JsonBody.last_seen_at)) "Expected last_seen_at after egress."
+    Assert-Condition ($agentStatus.JsonBody.presence -eq 'online') "Expected presence=online immediately after egress."
 
     $auditEntries = Wait-ForAuditEntries -AgentId $agentId -Headers $adminHeaders -RequiredActions @(
         "agents.bundle_downloaded",
@@ -581,7 +582,8 @@ try {
         accepted      = $egress.JsonBody.accepted
         duplicate     = $egress.JsonBody.duplicate
         event_types   = @($events | ForEach-Object { $_.event_type } | Select-Object -Unique)
-        last_heartbeat = $agentStatus.JsonBody.last_heartbeat
+        last_seen_at  = $agentStatus.JsonBody.last_seen_at
+        presence      = $agentStatus.JsonBody.presence
     }
     $happyPath.audit = [ordered]@{
         bundle_downloaded = Get-AuditActionCount -Entries $auditEntries -Action "agents.bundle_downloaded"


### PR DESCRIPTION
## Summary

The SAO agents list rendered every agent as **Offline** because `agent.state` is a static DB column that no code path ever updates. This PR derives presence server-side from `orion_egress_events.created_at` and surfaces a relative "last seen" caption in the AgentsPage card, with a 30s refresh interval so the dot tracks real activity.

This is **M2** of the cross-repo plan (M1 = temperature fix, already merged). No DB migration. No OrionII source changes.

## Backend

- `crates/sao-server/src/db/agents.rs`
  - New `last_egress_at_for_many` — single batched `SELECT agent_id, MAX(created_at) FROM orion_egress_events WHERE agent_id = ANY($1) GROUP BY agent_id` so the list endpoint stays O(1) queries regardless of agent count.
  - New `presence_from_last_seen(now, last_seen)` — `"online"` if the most recent egress was within 5 minutes, else `"offline"`.
- `crates/sao-server/src/routes/agents.rs`
  - `list_agents` now enriches each row with `last_seen_at` + `presence` via a new `AgentListItem` route DTO that flatten-wraps `AgentRow` (DB layer stays pure). Egress query failure is best-effort — surfaces all-Offline rather than 500ing the list.
  - `get_agent_status` and `update_agent_handler` rename `last_heartbeat` → `last_seen_at` (it was never a heartbeat protocol, just the most-recent egress timestamp) and add `presence`.

## Frontend

- `frontend/src/types/index.ts` — `Agent` and `AgentStatusResponse` gain `last_seen_at?` + `presence?`; `last_heartbeat` renamed on the latter.
- `frontend/src/lib/time-format.ts` (NEW) — `formatRelativeTime` using `Intl.RelativeTimeFormat`. No new dependencies.
- `frontend/src/pages/AgentsPage.tsx` — replaces broken `stateColor(agent.state)` with `presenceColor(agent.presence)`; adds a relative-time caption under each agent's UUID; `useQuery` gets `refetchInterval: 30_000` so the dot updates without a manual refresh.
- `frontend/src/pages/AgentEventsPage.tsx` — updated to read the renamed field.

## Cleanup

- `docs/STATUS.md`, `docs/runbooks/verify-orion-topic-shift.md`, and `scripts/verify-orion-topic-shift.ps1` updated to reference `last_seen_at` + `presence`. The PowerShell verify script now asserts both keys after egress.

## Why this design

- **Egress-only, no heartbeat.** OrionII publishes one egress envelope per chat round-trip (verified in `OrionII/src-tauri/src/orion/ego.rs:134-152`). Active chat keeps an agent green; idle cockpit correctly lapses to Offline after 5 min. Operator preference, locked in during planning.
- **Threshold lives in code (5 min).** Not an env var until M3+ proves we need one.
- **`agent.state` column preserved.** Untouched in this PR — reserved for a future "Disabled" admin action (M3.1+).

## Reviewer notes

- Field rename `last_heartbeat` → `last_seen_at` is a breaking change for any external consumer, but a grep confirmed only one frontend page (`AgentEventsPage`) and one PowerShell verify script read it. Both are updated in this PR.
- The list-endpoint best-effort fallback (egress query fails → all agents Offline) is intentional — degraded display beats a hard 500.

## Test plan

- [x] `cargo test -p sao-server` — 28 unit + 10 route_contracts pass
- [x] `npm run build` — tsc + vite clean
- [x] `npm test` — 15/15 vitest pass
- [x] `grep -rn 'last_heartbeat\|stateColor' C:/Repo/SAO` returns zero hits
- [ ] After deploy: open `/agents` in admin, send a chat from the cockpit, observe Just-Jim turn green within ~30s; idle 5 min, observe it go grey on the next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)