### PR TITLE
\ feat: vault passphrase lifecycle,installer artifact validation,dev helpers\

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ docker/empty-installer-mount/*.msi
 # OS
 .DS_Store
 Thumbs.db
+
+# Local dev output
+*.log
+compose-config.yml

--- a/README.md
+++ b/README.md
@@ -208,6 +208,29 @@ token for that agent (one live token per agent).
 > `/api/llm/generate` returns 503 (`vault is sealed`) until you POST `/api/vault/unseal`
 > from the admin UI.
 
+### Vault passphrase lifecycle
+
+The vault master key is sealed by an Argon2id-derived key, and the passphrase
+that derives that key has its own admin-only lifecycle:
+
+- `POST /api/vault/configure` (first-time setup): generates a fresh master
+  key and seals it with the supplied passphrase. Returns `409
+  vault_already_initialized` if a master key already exists; first-time
+  configure never overwrites an existing vault.
+- `POST /api/vault/rotate-passphrase`: requires the current passphrase, then
+  re-seals the *same* master key with a new Argon2id salt and a fresh AEAD
+  nonce. Existing encrypted secrets stay valid because the master key bytes
+  do not change. Returns `auto_unseal_env_stale: true` when
+  `SAO_VAULT_PASSPHRASE` is set, prompting you to rotate the deployment-side
+  secret before the next restart.
+
+Both endpoints are CSRF-gated, admin-only, audited (`vault.configure`,
+`vault.rotate_passphrase`, `vault.rotate_passphrase.failed`) and rate-limited
+to 5 requests per 5 minutes per IP. The `/vault` page exposes the same flows
+in the UI: a first-time **Configure vault passphrase** card when the vault is
+uninitialized, and a **Rotate passphrase** action available to admins from
+both the sealed unseal screen and the unsealed secrets list.
+
 ## Development & Contributing
 
 For local development, the Azure installer is still the production story, but the repo includes a local Compose workflow for integration work:
@@ -276,6 +299,23 @@ python -m unittest discover installer/tests
 POSTGRES_PASSWORD=local-dev-only-change-me docker compose -f docker/docker-compose.yml config
 az bicep build --file installer/bicep/main.bicep
 ```
+
+Windows local dev note: `webauthn-rs` pulls `openssl-sys` transitively, and
+`.cargo/config.toml` pins `+crt-static` for `x86_64-pc-windows-msvc`. Running
+`cargo build` directly on Windows therefore needs `OPENSSL_DIR`,
+`OPENSSL_LIB_DIR`, and `OPENSSL_STATIC` pointed at an OpenSSL-Win64 install
+(see the comment block in `.cargo/config.toml`). The helper script
+`scripts/build-windows.ps1` sets these for you and forwards the rest of the
+arguments to cargo:
+
+```powershell
+pwsh -File scripts/build-windows.ps1
+pwsh -File scripts/build-windows.ps1 -Cargo "test --workspace"
+pwsh -File scripts/build-windows.ps1 -Cargo "clippy --workspace --all-targets -- -D warnings"
+```
+
+The Linux CI image (`.github/workflows/ci.yml`) installs `libssl-dev`
+system-wide, so it does not need this script.
 
 Repository notes:
 

--- a/crates/sao-server/src/db/vault_key.rs
+++ b/crates/sao-server/src/db/vault_key.rs
@@ -52,3 +52,43 @@ pub async fn insert_vmk(
     .await?;
     Ok(())
 }
+
+/// Rotate the passphrase envelope for an existing VMK row.
+///
+/// The underlying VaultMasterKey bytes are *not* changed; only the
+/// passphrase-derived envelope (sealed ciphertext, KDF salt, AEAD nonce) is
+/// replaced. Existing secret ciphertexts therefore stay valid.
+///
+/// This intentionally updates the existing row in place (and stamps
+/// `rotated_at`) rather than inserting a new row, so `get_vmk()` keeps
+/// returning a single source of truth for the current envelope and we never
+/// race a stale row.
+pub async fn rotate_vmk_envelope(
+    pool: &PgPool,
+    id: i32,
+    encrypted_key: &[u8],
+    kdf_salt: &[u8],
+    kdf_memory_cost: i32,
+    kdf_time_cost: i32,
+    kdf_parallelism: i32,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE vault_master_key \
+         SET encrypted_key = $2, \
+             kdf_salt = $3, \
+             kdf_memory_cost = $4, \
+             kdf_time_cost = $5, \
+             kdf_parallelism = $6, \
+             rotated_at = now() \
+         WHERE id = $1",
+    )
+    .bind(id)
+    .bind(encrypted_key)
+    .bind(kdf_salt)
+    .bind(kdf_memory_cost)
+    .bind(kdf_time_cost)
+    .bind(kdf_parallelism)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() == 1)
+}

--- a/crates/sao-server/src/installers.rs
+++ b/crates/sao-server/src/installers.rs
@@ -15,6 +15,14 @@ use tokio::io::AsyncWriteExt;
 
 use crate::db::installer_sources::InstallerSourceRow;
 
+/// Installer kind for OrionII Windows MSI artifacts (the only kind today).
+pub const KIND_ORION_MSI: &str = "orion-msi";
+
+/// OLE2 compound document file signature. All Microsoft Installer (.msi)
+/// packages start with these eight bytes; msiexec rejects anything else
+/// with "This installation package could not be opened."
+const MSI_MAGIC: [u8; 8] = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
+
 #[allow(dead_code)] // NotConfigured reserved for callers that don't pre-check the DB
 #[derive(Debug, Error)]
 pub enum InstallerError {
@@ -24,13 +32,76 @@ pub enum InstallerError {
     Http(String),
     #[error("installer hash mismatch (expected {expected}, got {actual})")]
     HashMismatch { expected: String, actual: String },
+    #[error("installer content rejected: {reason} (looks like {looks_like})")]
+    InvalidContent { reason: String, looks_like: String },
     #[error("installer io: {0}")]
     Io(#[from] std::io::Error),
 }
 
+/// Best-effort hint for "what file format does this byte stream look like?"
+/// used purely to give operators a clear error when they paste the wrong URL
+/// (e.g. registering a GitHub source-tarball as if it were an MSI).
+pub fn sniff_format(bytes: &[u8]) -> &'static str {
+    if bytes.is_empty() {
+        return "empty body";
+    }
+    if bytes.len() >= MSI_MAGIC.len() && bytes[..MSI_MAGIC.len()] == MSI_MAGIC {
+        return "Windows Installer (.msi / OLE2 compound document)";
+    }
+    if bytes.starts_with(b"PK\x03\x04") || bytes.starts_with(b"PK\x05\x06") {
+        return "ZIP archive (PK\\x03\\x04) — likely a GitHub source-code archive, not a built MSI";
+    }
+    if bytes.starts_with(b"MZ") {
+        return "Windows PE executable (MZ) — likely a .exe installer, not an .msi";
+    }
+    if bytes.starts_with(b"%PDF-") {
+        return "PDF document";
+    }
+    if bytes.starts_with(b"\x7FELF") {
+        return "Linux ELF executable";
+    }
+    let prefix = &bytes[..bytes.len().min(512)];
+    let snippet = std::str::from_utf8(prefix).unwrap_or("");
+    let lower = snippet.to_ascii_lowercase();
+    if lower.contains("<!doctype html") || lower.contains("<html") {
+        "HTML document — the URL probably returned an error page or a sign-in interstitial"
+    } else if lower.contains("not found") || lower.contains("404") {
+        "HTTP error response body"
+    } else if prefix
+        .iter()
+        .all(|b| b.is_ascii() && (*b == b'\n' || *b == b'\r' || *b >= 0x20))
+    {
+        "ASCII text"
+    } else {
+        "unknown / binary blob"
+    }
+}
+
+/// Verify that `bytes` is acceptable for the given installer `kind`.
+///
+/// For `KIND_ORION_MSI` this enforces the OLE2 compound-document magic bytes
+/// at the start of the file, so a Windows host will be able to open the
+/// resulting bundle with `msiexec`. Returns a categorical
+/// `InvalidContent` error with a clear `looks_like` hint on rejection.
+pub fn validate_artifact_for_kind(kind: &str, bytes: &[u8]) -> Result<(), InstallerError> {
+    match kind {
+        KIND_ORION_MSI => {
+            if bytes.len() < MSI_MAGIC.len() || bytes[..MSI_MAGIC.len()] != MSI_MAGIC {
+                return Err(InstallerError::InvalidContent {
+                    reason: "URL did not return a valid Windows Installer (.msi) package".into(),
+                    looks_like: sniff_format(bytes).to_string(),
+                });
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 /// Returns the local path to the cached installer for `source`, downloading if absent.
-/// On success the file at the returned path is byte-for-byte the upstream artifact and its
-/// sha256 matches `source.expected_sha256`.
+/// On success the file at the returned path is byte-for-byte the upstream artifact, its
+/// sha256 matches `source.expected_sha256`, and its file format matches the kind of
+/// installer the row claims to be (e.g. OLE2 magic for `orion-msi`).
 pub async fn fetch_or_cache(source: &InstallerSourceRow) -> Result<PathBuf, InstallerError> {
     let cache_dir = installers_root().join(&source.expected_sha256);
     let target = cache_dir.join(&source.filename);
@@ -39,13 +110,27 @@ pub async fn fetch_or_cache(source: &InstallerSourceRow) -> Result<PathBuf, Inst
         // Re-verify on every serve — cheap insurance against bit-rot or substitution.
         let actual = sha256_of_file(&target).await?;
         if actual.eq_ignore_ascii_case(&source.expected_sha256) {
-            return Ok(target);
+            // Also re-validate the kind-specific file signature: an attacker (or a
+            // bug in an earlier release) could have planted bytes that pass sha
+            // but aren't the expected format.
+            let header = read_header(&target).await?;
+            if let Err(e) = validate_artifact_for_kind(&source.kind, &header) {
+                tracing::warn!(
+                    path = %target.display(),
+                    error = %e,
+                    "Cached installer failed kind-specific validation — refetching",
+                );
+                let _ = tokio::fs::remove_file(&target).await;
+            } else {
+                return Ok(target);
+            }
+        } else {
+            tracing::warn!(
+                path = %target.display(),
+                "Cached installer hash mismatch — refetching"
+            );
+            let _ = tokio::fs::remove_file(&target).await;
         }
-        tracing::warn!(
-            path = %target.display(),
-            "Cached installer hash mismatch — refetching"
-        );
-        let _ = tokio::fs::remove_file(&target).await;
     }
 
     tokio::fs::create_dir_all(&cache_dir).await?;
@@ -71,6 +156,10 @@ pub async fn fetch_or_cache(source: &InstallerSourceRow) -> Result<PathBuf, Inst
         .bytes()
         .await
         .map_err(|e| InstallerError::Http(e.to_string()))?;
+
+    // Validate format BEFORE writing to disk so we never cache non-installer bytes.
+    validate_artifact_for_kind(&source.kind, &body)?;
+
     let mut hasher = Sha256::new();
     hasher.update(&body);
     let mut tmp = tokio::fs::File::create(&target).await?;
@@ -93,6 +182,15 @@ pub async fn fetch_or_cache(source: &InstallerSourceRow) -> Result<PathBuf, Inst
     Ok(target)
 }
 
+async fn read_header(path: &Path) -> std::io::Result<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+    let mut f = tokio::fs::File::open(path).await?;
+    let mut buf = vec![0u8; 4096];
+    let n = f.read(&mut buf).await?;
+    buf.truncate(n);
+    Ok(buf)
+}
+
 /// Locate a previously cached installer by its sha256 (used when serving a pinned bundle).
 pub fn cached_path(sha256: &str, filename: &str) -> Option<PathBuf> {
     let p = installers_root().join(sha256).join(filename);
@@ -103,9 +201,26 @@ pub fn cached_path(sha256: &str, filename: &str) -> Option<PathBuf> {
     }
 }
 
-/// Compute sha256 of a file you intend to register as a source. Useful for the admin flow:
-/// admin uploads or points at a URL, server confirms the sha matches what they expect.
-pub async fn sha256_of_url(url: &str) -> Result<String, InstallerError> {
+/// Result of probing an upstream installer URL for the admin UI: sha256, byte
+/// count, and a best-effort format hint. The probe is non-destructive — it does
+/// not persist anything — but it does run kind-specific magic-byte validation
+/// for the caller's chosen `kind`, populating `format_ok` so the admin UI can
+/// gate the "Register" button on the artifact actually being an installer.
+#[derive(Debug, Clone)]
+pub struct InstallerProbe {
+    pub sha256: String,
+    pub size_bytes: u64,
+    pub format_hint: String,
+    pub format_ok: bool,
+    pub format_error: Option<String>,
+}
+
+/// Compute sha256 of a file you intend to register as a source and run the
+/// kind-specific format check. The format check is advisory at probe time
+/// (returned as `format_ok`) so the admin still sees the sha for diagnostic
+/// purposes, but the caller can refuse to persist a source whose
+/// `format_ok=false`.
+pub async fn probe_url(url: &str, kind: &str) -> Result<InstallerProbe, InstallerError> {
     let resp = reqwest::Client::new()
         .get(url)
         .send()
@@ -123,7 +238,19 @@ pub async fn sha256_of_url(url: &str) -> Result<String, InstallerError> {
         .map_err(|e| InstallerError::Http(e.to_string()))?;
     let mut hasher = Sha256::new();
     hasher.update(&body);
-    Ok(format!("{:x}", hasher.finalize()))
+    let sha256 = format!("{:x}", hasher.finalize());
+    let format_hint = sniff_format(&body).to_string();
+    let (format_ok, format_error) = match validate_artifact_for_kind(kind, &body) {
+        Ok(()) => (true, None),
+        Err(e) => (false, Some(e.to_string())),
+    };
+    Ok(InstallerProbe {
+        sha256,
+        size_bytes: body.len() as u64,
+        format_hint,
+        format_ok,
+        format_error,
+    })
 }
 
 async fn sha256_of_file(path: &Path) -> std::io::Result<String> {
@@ -146,4 +273,91 @@ fn installers_root() -> PathBuf {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/data/sao"));
     base.join("installers")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        sniff_format, validate_artifact_for_kind, InstallerError, KIND_ORION_MSI, MSI_MAGIC,
+    };
+
+    fn msi_header() -> Vec<u8> {
+        let mut b = Vec::with_capacity(64);
+        b.extend_from_slice(&MSI_MAGIC);
+        b.extend_from_slice(&[0u8; 56]);
+        b
+    }
+
+    #[test]
+    fn validator_accepts_msi_magic_for_orion_msi_kind() {
+        assert!(validate_artifact_for_kind(KIND_ORION_MSI, &msi_header()).is_ok());
+    }
+
+    #[test]
+    fn validator_rejects_zip_archive_for_orion_msi_kind() {
+        // GitHub source-tarball signature — the operator pitfall this guards against.
+        let zip = b"PK\x03\x04...rest of zip...";
+        match validate_artifact_for_kind(KIND_ORION_MSI, zip) {
+            Err(InstallerError::InvalidContent { looks_like, .. }) => {
+                assert!(
+                    looks_like.contains("ZIP"),
+                    "hint should mention ZIP, got {looks_like}",
+                );
+            }
+            other => panic!("expected InvalidContent error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validator_rejects_pe_executable_for_orion_msi_kind() {
+        // .exe self-installer (NSIS / Inno) — also not an .msi
+        let pe = b"MZ\x90\x00\x03\x00...PE header...";
+        match validate_artifact_for_kind(KIND_ORION_MSI, pe) {
+            Err(InstallerError::InvalidContent { looks_like, .. }) => {
+                assert!(
+                    looks_like.contains("PE") || looks_like.contains(".exe"),
+                    "hint should mention PE/.exe, got {looks_like}",
+                );
+            }
+            other => panic!("expected InvalidContent error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validator_rejects_html_error_page_for_orion_msi_kind() {
+        let html = b"<!DOCTYPE html><html><head><title>Not Found</title></head></html>";
+        match validate_artifact_for_kind(KIND_ORION_MSI, html) {
+            Err(InstallerError::InvalidContent { looks_like, .. }) => {
+                assert!(
+                    looks_like.to_ascii_lowercase().contains("html"),
+                    "hint should mention HTML, got {looks_like}",
+                );
+            }
+            other => panic!("expected InvalidContent error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validator_rejects_truncated_input_for_orion_msi_kind() {
+        let too_short = vec![0xD0, 0xCF, 0x11]; // first 3 bytes only
+        assert!(validate_artifact_for_kind(KIND_ORION_MSI, &too_short).is_err());
+    }
+
+    #[test]
+    fn validator_is_a_no_op_for_unknown_kinds() {
+        // Forward-compatible: unknown kinds opt out of the magic check.
+        assert!(validate_artifact_for_kind("future-kind", b"anything").is_ok());
+    }
+
+    #[test]
+    fn sniff_format_recognises_common_signatures() {
+        assert!(sniff_format(&msi_header()).contains("Windows Installer"));
+        assert!(sniff_format(b"PK\x03\x04anything").contains("ZIP"));
+        assert!(sniff_format(b"MZ\x90\x00").contains("PE"));
+        assert!(sniff_format(b"%PDF-1.4").contains("PDF"));
+        assert!(sniff_format(b"<!DOCTYPE html><html>")
+            .to_ascii_lowercase()
+            .contains("html"));
+        assert_eq!(sniff_format(&[]), "empty body");
+    }
 }

--- a/crates/sao-server/src/routes/admin.rs
+++ b/crates/sao-server/src/routes/admin.rs
@@ -644,9 +644,11 @@ async fn update_llm_provider(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    if let Err(error) =
-        validate_enabled_provider_model_contract(req.enabled, &approved_model_names, default_model.as_deref())
-    {
+    if let Err(error) = validate_enabled_provider_model_contract(
+        req.enabled,
+        &approved_model_names,
+        default_model.as_deref(),
+    ) {
         return (StatusCode::BAD_REQUEST, Json(json!({ "error": error })));
     }
     let approved_models = json!(approved_model_names);
@@ -734,9 +736,7 @@ fn validate_enabled_provider_model_contract(
     }
 
     if approved_models.is_empty() {
-        return Err(
-            "Select at least one approved model before enabling this provider".to_string(),
-        );
+        return Err("Select at least one approved model before enabling this provider".to_string());
     }
 
     let default_model = default_model
@@ -1036,10 +1036,14 @@ async fn list_installer_sources(
 #[derive(Deserialize)]
 struct ProbeInstallerRequest {
     url: String,
+    #[serde(default = "default_kind")]
+    kind: String,
 }
 
 /// Compute the sha256 of an upstream URL without persisting anything. Lets the admin
-/// confirm the hash before they commit it as `expected_sha256`.
+/// confirm the hash before they commit it as `expected_sha256`. Also runs a kind-specific
+/// format check (e.g. OLE2 magic for `orion-msi`) so the UI can warn the operator before
+/// they ever click "Register" with a URL that returns a ZIP source archive or HTML page.
 async fn probe_installer_source(
     AdminUser(_admin): AdminUser,
     Json(req): Json<ProbeInstallerRequest>,
@@ -1050,10 +1054,17 @@ async fn probe_installer_source(
             Json(json!({ "error": "url is required" })),
         );
     }
-    match crate::installers::sha256_of_url(req.url.trim()).await {
-        Ok(sha) => (
+    match crate::installers::probe_url(req.url.trim(), &req.kind).await {
+        Ok(probe) => (
             StatusCode::OK,
-            Json(json!({ "url": req.url, "sha256": sha })),
+            Json(json!({
+                "url": req.url,
+                "sha256": probe.sha256,
+                "size_bytes": probe.size_bytes,
+                "format_hint": probe.format_hint,
+                "format_ok": probe.format_ok,
+                "format_error": probe.format_error,
+            })),
         ),
         Err(e) => (
             StatusCode::BAD_GATEWAY,
@@ -1111,6 +1122,49 @@ async fn create_installer_source(
         );
     }
 
+    // Probe before persisting so we never store an installer source whose URL returns
+    // bytes that can't actually be installed (the classic operator pitfall is pasting a
+    // GitHub /archive/refs/tags/<tag>.zip URL — that's a source-code archive, not an MSI).
+    match crate::installers::probe_url(req.url.trim(), &req.kind).await {
+        Ok(probe) => {
+            if !probe
+                .sha256
+                .eq_ignore_ascii_case(req.expected_sha256.trim())
+            {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "error": "expected_sha256 does not match the URL's current sha256",
+                        "code": "sha_mismatch",
+                        "url_sha256": probe.sha256,
+                        "expected_sha256": req.expected_sha256.trim().to_lowercase(),
+                    })),
+                );
+            }
+            if !probe.format_ok {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "error": probe.format_error.clone()
+                            .unwrap_or_else(|| "URL did not return a valid installer artifact".to_string()),
+                        "code": "invalid_installer_artifact",
+                        "format_hint": probe.format_hint,
+                        "looks_like": probe.format_hint,
+                    })),
+                );
+            }
+        }
+        Err(e) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({
+                    "error": format!("Failed to probe URL: {e}"),
+                    "code": "probe_failed",
+                })),
+            );
+        }
+    }
+
     let row = match crate::db::installer_sources::insert(
         &state.inner.db,
         &req.kind,
@@ -1132,7 +1186,10 @@ async fn create_installer_source(
         }
     };
 
-    // Pre-warm the cache so the next bundle download is instant. Failure here is non-fatal.
+    // Pre-warm the cache so the next bundle download is instant. The probe above already
+    // validated content, so a failure here is something operationally weird (disk full,
+    // upstream flapped, etc.) — surface it but don't fail the registration since the row
+    // is committed and the cache will fill on first download.
     let pre_warm = match crate::installers::fetch_or_cache(&row).await {
         Ok(path) => json!({ "ok": true, "cache_path": path.display().to_string() }),
         Err(e) => json!({ "ok": false, "error": e.to_string() }),

--- a/crates/sao-server/src/routes/bundle.rs
+++ b/crates/sao-server/src/routes/bundle.rs
@@ -440,10 +440,20 @@ async fn resolve_installer(state: &AppState, agent: &AgentRow) -> Result<Vec<u8>
     if let (Some(sha), Some(filename)) = (&agent.installer_sha256, &agent.installer_filename) {
         if let Some(path) = crate::installers::cached_path(sha, filename) {
             if let Ok(bytes) = tokio::fs::read(&path).await {
-                return Ok(bytes);
+                if let Err(e) = crate::installers::validate_artifact_for_kind("orion-msi", &bytes) {
+                    tracing::warn!(
+                        agent_id = %agent.id,
+                        sha = sha,
+                        error = %e,
+                        "Pinned installer cache failed format validation; refetching",
+                    );
+                    let _ = tokio::fs::remove_file(&path).await;
+                } else {
+                    return Ok(bytes);
+                }
             }
         }
-        // Cache miss — try to refetch from the installer_sources row that matches this sha.
+        // Cache miss / bad cache — try to refetch from the installer_sources row that matches this sha.
         if let Ok(rows) = crate::db::installer_sources::list(&state.inner.db).await {
             if let Some(source) = rows
                 .into_iter()
@@ -487,6 +497,11 @@ async fn resolve_installer(state: &AppState, agent: &AgentRow) -> Result<Vec<u8>
     // 3. Legacy env-var fallback (file mounted into the container).
     if let Ok(path) = std::env::var("SAO_ORION_INSTALLER_PATH") {
         if let Ok(bytes) = tokio::fs::read(&path).await {
+            if let Err(e) = crate::installers::validate_artifact_for_kind("orion-msi", &bytes) {
+                return Err(format!(
+                    "SAO_ORION_INSTALLER_PATH={path} is not a valid Windows Installer: {e}",
+                ));
+            }
             return Ok(bytes);
         }
     }

--- a/crates/sao-server/src/routes/vault.rs
+++ b/crates/sao-server/src/routes/vault.rs
@@ -8,12 +8,22 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::auth::middleware::AuthUser;
+use crate::auth::middleware::{AdminUser, AuthUser};
 use crate::state::AppState;
+
+/// Minimum vault passphrase length (NIST SP 800-63B "memorized secret").
+///
+/// We accept memorized secrets at this length and gate stronger entropy via
+/// rejecting a small list of common passwords. This deliberately does not
+/// require composition rules, which NIST advises against.
+pub const MIN_VAULT_PASSPHRASE_LEN: usize = 12;
+pub const MAX_VAULT_PASSPHRASE_LEN: usize = 4096;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/vault/status", get(vault_status))
+        .route("/api/vault/configure", post(configure_vault))
+        .route("/api/vault/rotate-passphrase", post(rotate_passphrase))
         .route("/api/vault/unseal", post(unseal_vault))
         .route("/api/vault/seal", post(seal_vault))
         .route("/api/vault/secrets", get(list_secrets))
@@ -27,7 +37,410 @@ async fn vault_status(State(state): State<AppState>) -> Json<Value> {
     let vs = state.inner.vault_state.read().await;
     Json(json!({
         "status": vs.status_str(),
+        "auto_unseal_env_present": auto_unseal_env_present(),
     }))
+}
+
+fn auto_unseal_env_present() -> bool {
+    std::env::var("SAO_VAULT_PASSPHRASE")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+}
+
+/// Server-side passphrase strength check.
+///
+/// Returns Err(public_error_message) when the passphrase is unacceptable.
+/// Public messages are deliberately neutral so a single failure mode does not
+/// leak which other constraint also failed.
+fn validate_passphrase_strength(passphrase: &str) -> Result<(), &'static str> {
+    let trimmed = passphrase.trim();
+    if trimmed.len() < MIN_VAULT_PASSPHRASE_LEN {
+        return Err("Passphrase is too short");
+    }
+    if passphrase.chars().count() > MAX_VAULT_PASSPHRASE_LEN {
+        return Err("Passphrase is too long");
+    }
+    if is_common_passphrase(trimmed) {
+        return Err("Passphrase is too common");
+    }
+    Ok(())
+}
+
+/// Tiny denylist of obviously unsafe passphrases. Not a substitute for the
+/// length floor; this just catches the most common values that beat the
+/// length check (e.g. "password1234", "letmeinplease").
+fn is_common_passphrase(passphrase: &str) -> bool {
+    const DENYLIST: &[&str] = &[
+        "password1234",
+        "passwordpassword",
+        "letmeinplease",
+        "changemechangeme",
+        "qwertyqwerty",
+        "qwerty123456",
+        "administrator",
+        "iloveyou1234",
+        "trustno1trustno1",
+        "welcome12345",
+        "monkeymonkey",
+        "dragondragon",
+        "sunshine1234",
+        "starwars1977",
+        "footballsuck",
+    ];
+    let lower = passphrase.to_ascii_lowercase();
+    DENYLIST.iter().any(|candidate| lower == *candidate)
+}
+
+#[derive(Deserialize)]
+struct ConfigureVaultRequest {
+    passphrase: String,
+    passphrase_confirmation: String,
+}
+
+/// First-time vault passphrase configuration.
+///
+/// Generates a fresh VaultMasterKey, derives a passphrase key with Argon2id,
+/// seals the VMK, and stores the envelope. Refuses (409) once the vault has
+/// already been configured, because overwriting the VMK would orphan every
+/// existing encrypted secret.
+async fn configure_vault(
+    user: AdminUser,
+    State(state): State<AppState>,
+    Json(req): Json<ConfigureVaultRequest>,
+) -> (StatusCode, Json<Value>) {
+    let admin = user.0;
+
+    if req.passphrase != req.passphrase_confirmation {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "Passphrase and confirmation do not match",
+                "code": "confirmation_mismatch",
+            })),
+        );
+    }
+
+    if let Err(reason) = validate_passphrase_strength(&req.passphrase) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": reason,
+                "code": "weak_passphrase",
+                "min_length": MIN_VAULT_PASSPHRASE_LEN,
+            })),
+        );
+    }
+
+    match crate::db::vault_key::vmk_exists(&state.inner.db).await {
+        Ok(true) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({
+                    "error": "Vault is already configured. Use /api/vault/rotate-passphrase to change the passphrase.",
+                    "code": "vault_already_initialized",
+                })),
+            );
+        }
+        Ok(false) => {}
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to check vault initialization state");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Vault state lookup failed" })),
+            );
+        }
+    }
+
+    let vmk = sao_core::vault::VaultMasterKey::generate();
+    let salt = sao_core::vault::generate_salt();
+    let passphrase_key = match sao_core::vault::kdf::derive_key_from_passphrase(
+        &req.passphrase,
+        &salt,
+        sao_core::vault::kdf::DEFAULT_MEMORY_COST,
+        sao_core::vault::kdf::DEFAULT_TIME_COST,
+        sao_core::vault::kdf::DEFAULT_PARALLELISM,
+    ) {
+        Ok(key) => key,
+        Err(e) => {
+            tracing::error!(error = %e, "Argon2 KDF failed during vault configure");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Failed to derive passphrase key" })),
+            );
+        }
+    };
+
+    let (sealed, nonce) = match vmk.seal(&passphrase_key) {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to seal new VMK during vault configure");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Failed to seal new vault master key" })),
+            );
+        }
+    };
+    let mut envelope = sealed;
+    envelope.extend_from_slice(&nonce);
+
+    if let Err(e) = crate::db::vault_key::insert_vmk(
+        &state.inner.db,
+        &envelope,
+        &salt,
+        sao_core::vault::kdf::DEFAULT_MEMORY_COST as i32,
+        sao_core::vault::kdf::DEFAULT_TIME_COST as i32,
+        sao_core::vault::kdf::DEFAULT_PARALLELISM as i32,
+    )
+    .await
+    {
+        tracing::error!(error = %e, "Failed to persist vault master key envelope");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "Failed to persist vault master key" })),
+        );
+    }
+
+    {
+        let mut vs = state.inner.vault_state.write().await;
+        *vs = crate::vault_state::VaultState::Unsealed(vmk);
+    }
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(admin.user_id),
+        None,
+        "vault.configure",
+        Some("vault_master_key"),
+        Some(json!({
+            "auto_unseal_env_present": auto_unseal_env_present(),
+        })),
+        None,
+        None,
+    )
+    .await;
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": "unsealed",
+            "auto_unseal_env_present": auto_unseal_env_present(),
+        })),
+    )
+}
+
+#[derive(Deserialize)]
+struct RotatePassphraseRequest {
+    current_passphrase: String,
+    new_passphrase: String,
+    new_passphrase_confirmation: String,
+}
+
+/// Rotate the vault passphrase.
+///
+/// Verifies the caller knows the current passphrase by re-deriving the KDF
+/// key and unsealing a *throwaway* copy of the VMK from the stored envelope.
+/// On success, generates a fresh KDF salt and re-seals the same VMK with the
+/// new passphrase-derived key. Existing secret ciphertexts stay valid because
+/// the VMK bytes never change.
+async fn rotate_passphrase(
+    user: AdminUser,
+    State(state): State<AppState>,
+    Json(req): Json<RotatePassphraseRequest>,
+) -> (StatusCode, Json<Value>) {
+    let admin = user.0;
+
+    if req.new_passphrase != req.new_passphrase_confirmation {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "New passphrase and confirmation do not match",
+                "code": "confirmation_mismatch",
+            })),
+        );
+    }
+
+    if req.new_passphrase == req.current_passphrase {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "New passphrase must be different from the current passphrase",
+                "code": "same_as_current",
+            })),
+        );
+    }
+
+    if let Err(reason) = validate_passphrase_strength(&req.new_passphrase) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": reason,
+                "code": "weak_passphrase",
+                "min_length": MIN_VAULT_PASSPHRASE_LEN,
+            })),
+        );
+    }
+
+    let vmk_row = match crate::db::vault_key::get_vmk(&state.inner.db).await {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({
+                    "error": "Vault is not configured yet. Use /api/vault/configure first.",
+                    "code": "vault_uninitialized",
+                })),
+            );
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to load vault master key envelope");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Failed to load vault master key envelope" })),
+            );
+        }
+    };
+
+    let current_key = match sao_core::vault::kdf::derive_key_from_passphrase(
+        &req.current_passphrase,
+        &vmk_row.kdf_salt,
+        vmk_row.kdf_memory_cost as u32,
+        vmk_row.kdf_time_cost as u32,
+        vmk_row.kdf_parallelism as u32,
+    ) {
+        Ok(key) => key,
+        Err(e) => {
+            tracing::error!(error = %e, "Argon2 KDF failed during passphrase rotation");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Failed to derive current passphrase key" })),
+            );
+        }
+    };
+
+    if vmk_row.encrypted_key.len() < 12 {
+        tracing::error!("Stored VMK envelope is too short to contain a nonce");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "Corrupted vault master key envelope" })),
+        );
+    }
+    let (current_ciphertext, current_nonce) = vmk_row
+        .encrypted_key
+        .split_at(vmk_row.encrypted_key.len() - 12);
+
+    let vmk = match sao_core::vault::VaultMasterKey::unseal(
+        current_ciphertext,
+        current_nonce,
+        &current_key,
+    ) {
+        Ok(key) => key,
+        Err(_) => {
+            let _ = crate::db::audit::insert_audit_log(
+                &state.inner.db,
+                Some(admin.user_id),
+                None,
+                "vault.rotate_passphrase.failed",
+                Some("vault_master_key"),
+                Some(json!({ "reason": "invalid_current_passphrase" })),
+                None,
+                None,
+            )
+            .await;
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({
+                    "error": "Current passphrase is incorrect",
+                    "code": "invalid_credentials",
+                })),
+            );
+        }
+    };
+
+    let new_salt = sao_core::vault::generate_salt();
+    let new_key = match sao_core::vault::kdf::derive_key_from_passphrase(
+        &req.new_passphrase,
+        &new_salt,
+        sao_core::vault::kdf::DEFAULT_MEMORY_COST,
+        sao_core::vault::kdf::DEFAULT_TIME_COST,
+        sao_core::vault::kdf::DEFAULT_PARALLELISM,
+    ) {
+        Ok(key) => key,
+        Err(e) => {
+            tracing::error!(error = %e, "Argon2 KDF failed deriving new passphrase key");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Failed to derive new passphrase key" })),
+            );
+        }
+    };
+
+    let (new_sealed, new_nonce) = match vmk.seal(&new_key) {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to seal VMK with new passphrase key");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Failed to seal vault master key with new passphrase" })),
+            );
+        }
+    };
+    let mut new_envelope = new_sealed;
+    new_envelope.extend_from_slice(&new_nonce);
+
+    match crate::db::vault_key::rotate_vmk_envelope(
+        &state.inner.db,
+        vmk_row.id,
+        &new_envelope,
+        &new_salt,
+        sao_core::vault::kdf::DEFAULT_MEMORY_COST as i32,
+        sao_core::vault::kdf::DEFAULT_TIME_COST as i32,
+        sao_core::vault::kdf::DEFAULT_PARALLELISM as i32,
+    )
+    .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::error!("Vault rotation update affected zero rows; envelope unchanged");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Vault rotation did not persist" })),
+            );
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to persist rotated vault master key envelope");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Failed to persist rotated vault master key envelope" })),
+            );
+        }
+    }
+
+    {
+        let mut vs = state.inner.vault_state.write().await;
+        *vs = crate::vault_state::VaultState::Unsealed(vmk);
+    }
+
+    let _ = crate::db::audit::insert_audit_log(
+        &state.inner.db,
+        Some(admin.user_id),
+        None,
+        "vault.rotate_passphrase",
+        Some("vault_master_key"),
+        Some(json!({
+            "auto_unseal_env_present": auto_unseal_env_present(),
+        })),
+        None,
+        None,
+    )
+    .await;
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": "unsealed",
+            "auto_unseal_env_stale": auto_unseal_env_present(),
+        })),
+    )
 }
 
 #[derive(Deserialize)]
@@ -385,5 +798,45 @@ async fn delete_secret(
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "error": e.to_string() })),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        is_common_passphrase, validate_passphrase_strength, MAX_VAULT_PASSPHRASE_LEN,
+        MIN_VAULT_PASSPHRASE_LEN,
+    };
+
+    #[test]
+    fn passphrase_below_minimum_length_is_rejected() {
+        let short = "Ab1!".repeat(2);
+        assert!(short.len() < MIN_VAULT_PASSPHRASE_LEN);
+        let err =
+            validate_passphrase_strength(&short).expect_err("short passphrase must be rejected");
+        assert!(err.to_lowercase().contains("short"));
+    }
+
+    #[test]
+    fn passphrase_meeting_minimum_is_accepted() {
+        let strong = "correct horse battery staple alpaca";
+        assert!(strong.len() >= MIN_VAULT_PASSPHRASE_LEN);
+        assert!(validate_passphrase_strength(strong).is_ok());
+    }
+
+    #[test]
+    fn passphrase_in_denylist_is_rejected_even_if_long_enough() {
+        assert!(is_common_passphrase("password1234"));
+        let err = validate_passphrase_strength("password1234")
+            .expect_err("denylisted passphrase must be rejected");
+        assert!(err.to_lowercase().contains("common"));
+    }
+
+    #[test]
+    fn passphrase_above_max_length_is_rejected_to_bound_kdf_cost() {
+        let absurd = "a".repeat(MAX_VAULT_PASSPHRASE_LEN + 1);
+        let err = validate_passphrase_strength(&absurd)
+            .expect_err("oversized passphrase must be rejected");
+        assert!(err.to_lowercase().contains("long"));
     }
 }

--- a/crates/sao-server/src/security.rs
+++ b/crates/sao-server/src/security.rs
@@ -515,6 +515,10 @@ fn rate_limit_bucket(method: &Method, path: &str) -> Option<(&'static str, usize
         }
         ("POST", "/api/auth/refresh") => Some(("refresh", 30, Duration::from_secs(60))),
         ("POST", "/api/vault/unseal") => Some(("vault-unseal", 5, Duration::from_secs(300))),
+        ("POST", "/api/vault/configure") => Some(("vault-configure", 5, Duration::from_secs(300))),
+        ("POST", "/api/vault/rotate-passphrase") => {
+            Some(("vault-rotate", 5, Duration::from_secs(300)))
+        }
         ("POST", "/api/admin/oidc/providers") => Some(("admin-oidc", 30, Duration::from_secs(60))),
         ("PUT", path) if path.starts_with("/api/admin/oidc/providers/") => {
             Some(("admin-oidc", 30, Duration::from_secs(60)))

--- a/crates/sao-server/tests/route_contracts.rs
+++ b/crates/sao-server/tests/route_contracts.rs
@@ -13,10 +13,38 @@ fn auth_routes_use_start_finish_paths() {
 fn vault_routes_use_vault_secrets_namespace() {
     let src = include_str!("../src/routes/vault.rs");
     assert!(src.contains("/api/vault/status"));
+    assert!(src.contains("/api/vault/configure"));
+    assert!(src.contains("/api/vault/rotate-passphrase"));
     assert!(src.contains("/api/vault/unseal"));
     assert!(src.contains("/api/vault/seal"));
     assert!(src.contains("/api/vault/secrets"));
     assert!(src.contains("/api/vault/secrets/:id"));
+}
+
+#[test]
+fn vault_passphrase_lifecycle_routes_are_admin_gated_and_rate_limited() {
+    let vault_src = include_str!("../src/routes/vault.rs");
+    let security_src = include_str!("../src/security.rs");
+
+    // Admin-gated lifecycle handlers
+    assert!(vault_src.contains("async fn configure_vault"));
+    assert!(vault_src.contains("async fn rotate_passphrase"));
+    assert!(vault_src.contains("user: AdminUser"));
+
+    // First-time configure must refuse to overwrite an existing VMK
+    assert!(vault_src.contains("vault_already_initialized"));
+    assert!(vault_src.contains("StatusCode::CONFLICT"));
+
+    // Rotation requires proving the current passphrase and rejects same-as-current
+    assert!(vault_src.contains("current_passphrase"));
+    assert!(vault_src.contains("same_as_current"));
+    assert!(vault_src.contains("invalid_credentials"));
+
+    // Both lifecycle routes are individually rate-limited
+    assert!(security_src.contains("\"/api/vault/configure\""));
+    assert!(security_src.contains("\"/api/vault/rotate-passphrase\""));
+    assert!(security_src.contains("vault-configure"));
+    assert!(security_src.contains("vault-rotate"));
 }
 
 #[test]
@@ -35,6 +63,25 @@ fn admin_routes_use_oidc_provider_namespace() {
     assert!(src.contains("/api/admin/users/:id/role"));
     assert!(src.contains("/api/admin/entity-archives"));
     assert!(src.contains("Cannot demote the last administrator"));
+}
+
+#[test]
+fn installer_source_registration_validates_artifact_format() {
+    let admin_src = include_str!("../src/routes/admin.rs");
+    let installer_src = include_str!("../src/installers.rs");
+
+    // Admin probe + create handlers must run the new probe path that returns
+    // format hints, and create must refuse to persist non-MSI artifacts.
+    assert!(admin_src.contains("crate::installers::probe_url"));
+    assert!(admin_src.contains("invalid_installer_artifact"));
+    assert!(admin_src.contains("sha_mismatch"));
+
+    // Format validator + sniffer live in the installers module and the
+    // fetch path runs validation BEFORE writing bytes to disk.
+    assert!(installer_src.contains("validate_artifact_for_kind"));
+    assert!(installer_src.contains("sniff_format"));
+    assert!(installer_src.contains("MSI_MAGIC"));
+    assert!(installer_src.contains("// Validate format BEFORE writing to disk"));
 }
 
 #[test]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -79,6 +79,15 @@ Docker Compose stack with a real Anthropic upstream:
 ### Operational ergonomics
 - **Auto-unseal** — `SAO_VAULT_PASSPHRASE` env var unseals on startup so LLM keys stay
   readable across container restarts. Wired through compose by default.
+- **Vault passphrase lifecycle** — `/admin/...`-style flows live on the
+  existing `/vault` page: first-time admins see a **Configure vault
+  passphrase** card when the vault is uninitialized; afterwards, admins can
+  open **Rotate passphrase** from either the sealed unseal screen or the
+  unsealed secrets list. Backed by `POST /api/vault/configure` (first-time;
+  refuses 409 once a VMK exists) and `POST /api/vault/rotate-passphrase`
+  (requires the current passphrase, re-seals the same VMK so existing
+  ciphertexts stay valid). Both are CSRF-gated, admin-only, audited, and
+  rate-limited.
 - **Self-serve installer staging** — no more host-shell access required to drop an MSI on
   the server. Admin pastes a URL; SAO downloads + verifies + caches.
 - **Sha-based pinning** — re-rolling the default installer never breaks existing agents;

--- a/docs/runbooks/local-orion-sao-mvp.md
+++ b/docs/runbooks/local-orion-sao-mvp.md
@@ -95,11 +95,18 @@ Set the base URL (`http://host.docker.internal:11434` from inside the SAO contai
 
 Go to **/admin/installer-sources** → **+ Register installer source**:
 
-1. Paste a download URL — convention is the GitHub Releases `latest` URL:
-   ```
-   https://github.com/jbcupps/OrionII/releases/latest/download/OrionII_0.1.1_x64_en-US.msi
-   ```
-   (Or any URL SAO can `GET`.)
+1. Paste a download URL. Two convention options:
+   - Tag-stable (only updated on `vX.Y.Z` tag pushes):
+     ```
+     https://github.com/jbcupps/OrionII/releases/latest/download/OrionII_0.1.1_x64_en-US.msi
+     ```
+   - Edge rolling (refreshed on every push to OrionII `main` + nightly):
+     ```
+     https://github.com/jbcupps/OrionII/releases/download/edge/OrionII_0.1.1_x64_en-US.msi
+     ```
+   Avoid `https://github.com/jbcupps/OrionII/archive/refs/tags/<tag>.zip` — that's
+   GitHub's auto-generated source-code archive, not an MSI; SAO will refuse to
+   register it.
 2. Click **Probe sha256** — SAO computes the digest of what it sees at that URL.
 3. Confirm the sha matches what you expect, then fill **Filename** + **Version label** (the
    form pre-fills sensible defaults).
@@ -238,6 +245,8 @@ FROM audit_log WHERE action LIKE 'llm.%' ORDER BY created_at DESC LIMIT 20;
 | `503 OrionII installer is not available` | No installer source registered AND no `SAO_ORION_INSTALLER_PATH` env var. | Register a source under `/admin/installer-sources` (preferred) or set the env var to a mounted MSI path. |
 | Bundle download 503 with sha-mismatch | Cached file doesn't match registered sha (substituted upstream / corruption). | SAO refetches automatically on the next call; if upstream is permanently gone, register a new source. |
 | OrionII shows `Degraded fallback` for MODEL after a fresh container start | Vault is sealed → LLM proxy can't decrypt the API key. | Set `SAO_VAULT_PASSPHRASE` so compose auto-unseals on startup. |
+| `/api/llm/generate` returns 503 `vault is sealed` after rotating the vault passphrase from the UI | `SAO_VAULT_PASSPHRASE` still holds the old value; auto-unseal failed at startup. | Update the deployment env (or `.env` for local Compose) with the new passphrase and restart, or POST `/api/vault/unseal` once with the new value. The UI surfaces this as `auto_unseal_env_stale` after a rotation. |
+| Windows shows `This installation package could not be opened` when running `OrionII-Setup.msi` from a downloaded bundle | The registered installer source URL doesn't return a built MSI — usually because it points at GitHub's `archive/refs/tags/<tag>.zip` source-tarball alias instead of `releases/download/<tag>/<asset>.msi`. msiexec sees ZIP magic (`50 4B 03 04`) instead of OLE2 magic (`D0 CF 11 E0`). Not a code-signing issue. | Open `/admin/installer-sources`, register a `releases/download/...msi` URL (the **Probe sha256** button now refuses non-MSIs and shows what it actually got). Bundle download will return `503` with a clear "looks like ZIP archive..." hint until a valid source is registered. |
 | OrionII chat returns the deterministic fallback text | `/api/llm/generate` is failing — check `audit_log` for `llm.generate.failed`. | Common causes: vault sealed, model not on approved list, upstream API rejected the key. |
 | `503 Vault is sealed` on the LLM endpoint | Same as above. | Set `SAO_VAULT_PASSPHRASE`. |
 | `400 Configured provider is currently disabled` | Admin disabled the provider after the agent was created. | Re-enable in `/admin/llm-providers`. |

--- a/frontend/src/api/api-contracts.test.ts
+++ b/frontend/src/api/api-contracts.test.ts
@@ -5,7 +5,11 @@ import {
   listOidcProviders,
   queryAuditLog,
 } from './admin';
-import { listSecrets } from './vault';
+import {
+  configureVault,
+  listSecrets,
+  rotateVaultPassphrase,
+} from './vault';
 import { getMe, webauthnLoginStart } from './auth';
 import { deleteAgent, updateAgent } from './agents';
 import { listAvailableLlmProviders } from './llm-providers';
@@ -72,6 +76,66 @@ describe('frontend api contract adapters', () => {
         credentials: 'include',
       }),
     );
+  });
+
+  it('posts the configure-vault first-time setup payload with CSRF', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 'unsealed', auto_unseal_env_present: false }),
+    );
+
+    await configureVault({
+      passphrase: 'correct horse battery staple',
+      passphrase_confirmation: 'correct horse battery staple',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/vault/configure',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: expect.objectContaining({
+          'X-CSRF-Token': 'test-csrf-token',
+        }),
+      }),
+    );
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body).toEqual({
+      passphrase: 'correct horse battery staple',
+      passphrase_confirmation: 'correct horse battery staple',
+    });
+  });
+
+  it('posts the rotate-passphrase payload with current + new + confirmation', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 'unsealed', auto_unseal_env_stale: true }),
+    );
+
+    await rotateVaultPassphrase({
+      current_passphrase: 'old correct horse',
+      new_passphrase: 'new correct horse battery',
+      new_passphrase_confirmation: 'new correct horse battery',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/vault/rotate-passphrase',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: expect.objectContaining({
+          'X-CSRF-Token': 'test-csrf-token',
+        }),
+      }),
+    );
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body).toEqual({
+      current_passphrase: 'old correct horse',
+      new_passphrase: 'new correct horse battery',
+      new_passphrase_confirmation: 'new correct horse battery',
+    });
   });
 
   it('maps webauthn login start challenge to options', async () => {

--- a/frontend/src/api/installer-sources.ts
+++ b/frontend/src/api/installer-sources.ts
@@ -14,12 +14,13 @@ export async function listInstallerSources(): Promise<InstallerSource[]> {
 
 export async function probeInstallerSource(
   url: string,
+  kind: string = 'orion-msi',
 ): Promise<ProbeInstallerResult> {
   return apiRequest<ProbeInstallerResult>(
     '/api/admin/installer-sources/probe',
     {
       method: 'POST',
-      body: JSON.stringify({ url }),
+      body: JSON.stringify({ url, kind }),
     },
   );
 }

--- a/frontend/src/api/vault.ts
+++ b/frontend/src/api/vault.ts
@@ -1,13 +1,34 @@
 import { apiRequest } from './client';
 import type {
-  VaultStatus,
-  VaultSecret,
+  ConfigureVaultData,
   CreateSecretData,
+  RotateVaultPassphraseData,
   UpdateSecretData,
+  VaultLifecycleResponse,
+  VaultSecret,
+  VaultStatus,
 } from '../types';
 
 export async function getVaultStatus(): Promise<VaultStatus> {
   return apiRequest<VaultStatus>('/api/vault/status');
+}
+
+export async function configureVault(
+  data: ConfigureVaultData,
+): Promise<VaultLifecycleResponse> {
+  return apiRequest<VaultLifecycleResponse>('/api/vault/configure', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function rotateVaultPassphrase(
+  data: RotateVaultPassphraseData,
+): Promise<VaultLifecycleResponse> {
+  return apiRequest<VaultLifecycleResponse>('/api/vault/rotate-passphrase', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
 }
 
 export async function unsealVault(passphrase: string): Promise<void> {

--- a/frontend/src/hooks/useVault.ts
+++ b/frontend/src/hooks/useVault.ts
@@ -1,6 +1,17 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getVaultStatus, unsealVault, sealVault } from '../api/vault';
-import type { VaultStatus } from '../types';
+import {
+  configureVault,
+  getVaultStatus,
+  rotateVaultPassphrase,
+  sealVault,
+  unsealVault,
+} from '../api/vault';
+import type {
+  ConfigureVaultData,
+  RotateVaultPassphraseData,
+  VaultLifecycleResponse,
+  VaultStatus,
+} from '../types';
 import { useCallback } from 'react';
 
 export function useVault() {
@@ -29,14 +40,37 @@ export function useVault() {
     await queryClient.invalidateQueries({ queryKey: ['vault-status'] });
   }, [queryClient]);
 
+  const configure = useCallback(
+    async (data: ConfigureVaultData): Promise<VaultLifecycleResponse> => {
+      const result = await configureVault(data);
+      await queryClient.invalidateQueries({ queryKey: ['vault-status'] });
+      return result;
+    },
+    [queryClient],
+  );
+
+  const rotatePassphrase = useCallback(
+    async (
+      data: RotateVaultPassphraseData,
+    ): Promise<VaultLifecycleResponse> => {
+      const result = await rotateVaultPassphrase(data);
+      await queryClient.invalidateQueries({ queryKey: ['vault-status'] });
+      return result;
+    },
+    [queryClient],
+  );
+
   return {
     vaultStatus,
     isLoading,
     error,
     unseal,
     seal,
+    configure,
+    rotatePassphrase,
     isSealed: vaultStatus?.status === 'sealed',
     isUnsealed: vaultStatus?.status === 'unsealed',
     isUninitialized: vaultStatus?.status === 'uninitialized',
+    autoUnsealEnvPresent: vaultStatus?.auto_unseal_env_present === true,
   };
 }

--- a/frontend/src/pages/AdminInstallerSourcesPage.tsx
+++ b/frontend/src/pages/AdminInstallerSourcesPage.tsx
@@ -7,7 +7,7 @@ import {
   probeInstallerSource,
   setDefaultInstallerSource,
 } from '../api/installer-sources';
-import type { InstallerSource } from '../types';
+import type { InstallerSource, ProbeInstallerResult } from '../types';
 
 export default function AdminInstallerSourcesPage() {
   const queryClient = useQueryClient();
@@ -86,19 +86,19 @@ function CreateForm({ onCreated }: { onCreated: () => Promise<void> | void }) {
   const [isDefault, setIsDefault] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
-  const [probedSha, setProbedSha] = useState<string | null>(null);
+  const [probe, setProbe] = useState<ProbeInstallerResult | null>(null);
 
   const handleProbe = async () => {
     setError('');
-    setProbedSha(null);
+    setProbe(null);
     if (!url.trim()) {
       setError('URL is required');
       return;
     }
     setBusy(true);
     try {
-      const result = await probeInstallerSource(url.trim());
-      setProbedSha(result.sha256);
+      const result = await probeInstallerSource(url.trim(), 'orion-msi');
+      setProbe(result);
       if (!sha.trim()) setSha(result.sha256);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Probe failed');
@@ -126,9 +126,33 @@ function CreateForm({ onCreated }: { onCreated: () => Promise<void> | void }) {
     }
   };
 
+  const formatLooksWrong = probe !== null && probe.format_ok === false;
+  const formatVerified = probe !== null && probe.format_ok === true;
+  const canRegister =
+    !busy && !!url.trim() && !!sha.trim() && !formatLooksWrong;
+
   return (
     <div className="bg-gray-800 rounded-xl border border-gray-700 p-5 mb-6 space-y-3">
       <h2 className="text-lg font-semibold text-white">Register installer source</h2>
+      <div className="rounded-lg border border-slate-700 bg-slate-900/40 p-3 text-xs text-slate-400">
+        <p className="font-medium text-slate-300">Use a built-MSI release asset URL.</p>
+        <p className="mt-1">
+          GitHub Releases publishes built artifacts at{' '}
+          <span className="font-mono text-slate-200">
+            /releases/download/&lt;tag&gt;/&lt;asset&gt;.msi
+          </span>{' '}
+          or the convenience alias{' '}
+          <span className="font-mono text-slate-200">
+            /releases/latest/download/&lt;asset&gt;.msi
+          </span>
+          . URLs that look like{' '}
+          <span className="font-mono text-amber-300">
+            /archive/refs/tags/&lt;tag&gt;.zip
+          </span>{' '}
+          are GitHub-generated source-code archives, not installers, and SAO will
+          refuse to register them.
+        </p>
+      </div>
       <div>
         <label className="block text-xs text-gray-400 mb-1">Download URL</label>
         <div className="flex gap-2">
@@ -147,10 +171,46 @@ function CreateForm({ onCreated }: { onCreated: () => Promise<void> | void }) {
             Probe sha256
           </button>
         </div>
-        {probedSha && (
-          <p className="text-xs text-green-400 mt-1 font-mono break-all">
-            Computed: {probedSha}
-          </p>
+        {probe && (
+          <div className="mt-2 space-y-1 text-xs font-mono break-all">
+            <p className={formatVerified ? 'text-green-400' : 'text-amber-300'}>
+              sha256: {probe.sha256}
+            </p>
+            {typeof probe.size_bytes === 'number' && (
+              <p className="text-slate-400">
+                size: {probe.size_bytes.toLocaleString()} bytes
+              </p>
+            )}
+            {probe.format_hint && (
+              <p
+                className={
+                  formatVerified
+                    ? 'text-green-400 font-sans'
+                    : 'text-amber-300 font-sans'
+                }
+              >
+                format: {probe.format_hint}
+              </p>
+            )}
+          </div>
+        )}
+        {formatLooksWrong && (
+          <div className="mt-2 rounded border border-red-800 bg-red-900/30 p-3 text-xs text-red-200">
+            <p className="font-semibold">
+              This URL did not return a valid Windows Installer (.msi).
+            </p>
+            <p className="mt-1">
+              {probe?.format_error ||
+                'The first bytes of the response do not match the OLE2 magic that msiexec needs.'}
+            </p>
+            <p className="mt-2">
+              Likely cause: the URL is a GitHub source-tarball
+              (<span className="font-mono">/archive/refs/tags/...zip</span>) or a
+              release asset that has not been built/published yet. Use a{' '}
+              <span className="font-mono">/releases/download/&lt;tag&gt;/&lt;file&gt;.msi</span>{' '}
+              URL instead. Registration is blocked until this resolves.
+            </p>
+          </div>
         )}
       </div>
       <div className="grid grid-cols-2 gap-3">
@@ -199,10 +259,14 @@ function CreateForm({ onCreated }: { onCreated: () => Promise<void> | void }) {
       <div className="flex justify-end">
         <button
           onClick={handleCreate}
-          disabled={busy || !url.trim() || !sha.trim()}
-          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-900 text-white text-sm rounded-lg"
+          disabled={!canRegister}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-900 disabled:cursor-not-allowed text-white text-sm rounded-lg"
         >
-          {busy ? 'Working...' : 'Register + warm cache'}
+          {busy
+            ? 'Working...'
+            : formatLooksWrong
+              ? 'Format check failed'
+              : 'Register + warm cache'}
         </button>
       </div>
     </div>

--- a/frontend/src/pages/VaultPage.tsx
+++ b/frontend/src/pages/VaultPage.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useVault } from '../hooks/useVault';
+import { useAuth } from '../hooks/useAuth';
 import {
   listSecrets,
   createSecret,
@@ -9,6 +10,9 @@ import {
   deleteSecret,
 } from '../api/vault';
 import type { VaultSecret, CreateSecretData } from '../types';
+
+/** Must match `MIN_VAULT_PASSPHRASE_LEN` in `crates/sao-server/src/routes/vault.rs`. */
+const MIN_PASSPHRASE_LEN = 12;
 
 const SECRET_TYPES = [
   { value: 'api_key', label: 'API Key' },
@@ -382,13 +386,326 @@ function ViewSecretModal({
   );
 }
 
+function passphraseHints(passphrase: string, confirmation: string): string[] {
+  const hints: string[] = [];
+  if (passphrase.length === 0) {
+    hints.push(`At least ${MIN_PASSPHRASE_LEN} characters`);
+  } else if (passphrase.length < MIN_PASSPHRASE_LEN) {
+    hints.push(
+      `${MIN_PASSPHRASE_LEN - passphrase.length} more character${
+        MIN_PASSPHRASE_LEN - passphrase.length === 1 ? '' : 's'
+      } to reach the ${MIN_PASSPHRASE_LEN}-character minimum`,
+    );
+  }
+  if (confirmation.length > 0 && confirmation !== passphrase) {
+    hints.push('Confirmation does not match');
+  }
+  return hints;
+}
+
+function ConfigureVaultCard({ isAdmin }: { isAdmin: boolean }) {
+  const { configure } = useVault();
+  const [passphrase, setPassphrase] = useState('');
+  const [confirmation, setConfirmation] = useState('');
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const hints = useMemo(
+    () => passphraseHints(passphrase, confirmation),
+    [passphrase, confirmation],
+  );
+  const canSubmit =
+    isAdmin &&
+    !saving &&
+    passphrase.length >= MIN_PASSPHRASE_LEN &&
+    passphrase === confirmation;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSaving(true);
+    try {
+      await configure({
+        passphrase,
+        passphrase_confirmation: confirmation,
+      });
+      setPassphrase('');
+      setConfirmation('');
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to configure vault passphrase',
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto mt-12">
+      <div className="rounded-2xl border border-slate-800 bg-gradient-to-b from-slate-900 to-slate-950 shadow-xl p-8">
+        <p className="text-xs uppercase tracking-[0.3em] text-cyan-300">
+          First-time setup
+        </p>
+        <h2 className="mt-2 text-xl font-semibold text-white">
+          Configure the vault passphrase
+        </h2>
+        <p className="mt-3 text-sm text-slate-400">
+          Choose a strong passphrase. SAO derives an Argon2id key from it and
+          uses that key to seal the vault master key. The passphrase is never
+          stored. Encrypted secrets stay valid forever; only the envelope
+          changes when you rotate.
+        </p>
+
+        {!isAdmin ? (
+          <div className="mt-6 rounded-xl border border-slate-700 bg-slate-900/70 p-4 text-sm text-slate-300">
+            The vault has not been configured yet. Ask a SAO administrator to
+            sign in and complete this step before you can store secrets.
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1">
+                New passphrase
+              </label>
+              <input
+                type="password"
+                autoComplete="new-password"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                placeholder={`At least ${MIN_PASSPHRASE_LEN} characters`}
+                className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1">
+                Confirm passphrase
+              </label>
+              <input
+                type="password"
+                autoComplete="new-password"
+                value={confirmation}
+                onChange={(e) => setConfirmation(e.target.value)}
+                placeholder="Repeat the passphrase"
+                className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500"
+                required
+              />
+            </div>
+
+            {hints.length > 0 && (
+              <ul className="space-y-1 text-xs text-amber-300">
+                {hints.map((hint) => (
+                  <li key={hint}>{hint}</li>
+                ))}
+              </ul>
+            )}
+            {error && <p className="text-sm text-red-400">{error}</p>}
+
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="w-full px-4 py-2.5 bg-cyan-600 hover:bg-cyan-500 disabled:bg-slate-700 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors"
+            >
+              {saving ? 'Configuring...' : 'Configure vault'}
+            </button>
+            <p className="text-xs text-slate-500">
+              Tip: store this passphrase in your team password manager and in
+              the deployment <code>SAO_VAULT_PASSPHRASE</code> secret so the
+              vault auto-unseals on every restart.
+            </p>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RotatePassphraseModal({
+  onClose,
+  autoUnsealEnvPresent,
+}: {
+  onClose: () => void;
+  autoUnsealEnvPresent: boolean;
+}) {
+  const { rotatePassphrase } = useVault();
+  const [current, setCurrent] = useState('');
+  const [next, setNext] = useState('');
+  const [confirmation, setConfirmation] = useState('');
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [stale, setStale] = useState(false);
+
+  const hints = useMemo(
+    () => passphraseHints(next, confirmation),
+    [next, confirmation],
+  );
+  const canSubmit =
+    !saving &&
+    current.length > 0 &&
+    next.length >= MIN_PASSPHRASE_LEN &&
+    next === confirmation &&
+    next !== current;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSaving(true);
+    try {
+      const result = await rotatePassphrase({
+        current_passphrase: current,
+        new_passphrase: next,
+        new_passphrase_confirmation: confirmation,
+      });
+      setCurrent('');
+      setNext('');
+      setConfirmation('');
+      setSuccess(true);
+      setStale(result.auto_unseal_env_stale === true);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to rotate passphrase',
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal title="Rotate vault passphrase" onClose={onClose}>
+      {success ? (
+        <div className="space-y-4">
+          <p className="text-sm text-emerald-300">
+            Vault passphrase rotated successfully.
+          </p>
+          {stale && (
+            <div className="rounded-lg border border-amber-700 bg-amber-900/20 p-4 text-sm text-amber-200">
+              <p className="font-medium">
+                Update <code>SAO_VAULT_PASSPHRASE</code> in your deployment.
+              </p>
+              <p className="mt-1 text-amber-300/90">
+                Auto-unseal currently still uses the old value. The next
+                container restart will boot the vault sealed unless the
+                deployment-side secret is rotated to match.
+              </p>
+            </div>
+          )}
+          <div className="pt-2">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-cyan-600 hover:bg-cyan-500 text-white font-medium rounded-lg transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <p className="text-sm text-slate-400">
+            The current passphrase is required. The vault master key itself
+            does not change, so existing encrypted secrets stay valid.
+          </p>
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-1">
+              Current passphrase
+            </label>
+            <input
+              type="password"
+              autoComplete="current-password"
+              value={current}
+              onChange={(e) => setCurrent(e.target.value)}
+              className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-1">
+              New passphrase
+            </label>
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={next}
+              onChange={(e) => setNext(e.target.value)}
+              placeholder={`At least ${MIN_PASSPHRASE_LEN} characters`}
+              className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-1">
+              Confirm new passphrase
+            </label>
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={confirmation}
+              onChange={(e) => setConfirmation(e.target.value)}
+              className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500"
+              required
+            />
+          </div>
+
+          {next.length > 0 && next === current && (
+            <p className="text-xs text-amber-300">
+              New passphrase must differ from the current one
+            </p>
+          )}
+          {hints.length > 0 && (
+            <ul className="space-y-1 text-xs text-amber-300">
+              {hints.map((hint) => (
+                <li key={hint}>{hint}</li>
+              ))}
+            </ul>
+          )}
+          {autoUnsealEnvPresent && (
+            <p className="text-xs text-slate-400">
+              <code>SAO_VAULT_PASSPHRASE</code> is currently set in the
+              deployment. After rotating here, update that secret to match
+              before the next restart.
+            </p>
+          )}
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-slate-200 font-medium rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="flex-1 px-4 py-2 bg-cyan-600 hover:bg-cyan-500 disabled:bg-slate-700 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors"
+            >
+              {saving ? 'Rotating...' : 'Rotate passphrase'}
+            </button>
+          </div>
+        </form>
+      )}
+    </Modal>
+  );
+}
+
 export default function VaultPage() {
-  const { vaultStatus, isSealed, unseal } = useVault();
+  const {
+    vaultStatus,
+    isUninitialized,
+    isSealed,
+    unseal,
+    autoUnsealEnvPresent,
+  } = useVault();
+  const { isAdmin } = useAuth();
   const [passphrase, setPassphrase] = useState('');
   const [unsealError, setUnsealError] = useState('');
   const [unsealLoading, setUnsealLoading] = useState(false);
   const [showAdd, setShowAdd] = useState(false);
   const [viewSecretId, setViewSecretId] = useState<string | null>(null);
+  const [showRotate, setShowRotate] = useState(false);
 
   const { data: secrets, isLoading } = useQuery({
     queryKey: ['secrets'],
@@ -415,7 +732,18 @@ export default function VaultPage() {
     return SECRET_TYPES.find((t) => t.value === type)?.label || type;
   };
 
-  // Vault sealed state
+  // Vault never configured — show first-time configure card.
+  if (isUninitialized) {
+    return (
+      <div>
+        <h1 className="text-2xl font-bold text-white mb-6">Key Vault</h1>
+        <ConfigureVaultCard isAdmin={isAdmin} />
+      </div>
+    );
+  }
+
+  // Vault sealed — admin can unseal here, or rotate the passphrase if they
+  // know the current one.
   if (isSealed) {
     return (
       <div>
@@ -448,9 +776,24 @@ export default function VaultPage() {
               {unsealError && (
                 <p className="text-red-400 text-sm">{unsealError}</p>
               )}
+              {isAdmin && (
+                <button
+                  type="button"
+                  onClick={() => setShowRotate(true)}
+                  className="text-xs text-slate-400 hover:text-cyan-300 underline-offset-2 hover:underline"
+                >
+                  Rotate vault passphrase
+                </button>
+              )}
             </div>
           </div>
         </div>
+        {showRotate && (
+          <RotatePassphraseModal
+            onClose={() => setShowRotate(false)}
+            autoUnsealEnvPresent={autoUnsealEnvPresent}
+          />
+        )}
       </div>
     );
   }
@@ -459,12 +802,23 @@ export default function VaultPage() {
     <div>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-white">Key Vault</h1>
-        <button
-          onClick={() => setShowAdd(true)}
-          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors text-sm"
-        >
-          + Add Secret
-        </button>
+        <div className="flex items-center gap-2">
+          {isAdmin && (
+            <button
+              onClick={() => setShowRotate(true)}
+              className="px-3 py-2 bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm font-medium rounded-lg transition-colors"
+              title="Rotate the passphrase that seals the vault master key"
+            >
+              Rotate passphrase
+            </button>
+          )}
+          <button
+            onClick={() => setShowAdd(true)}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors text-sm"
+          >
+            + Add Secret
+          </button>
+        </div>
       </div>
 
       {isLoading ? (
@@ -528,6 +882,13 @@ export default function VaultPage() {
         <ViewSecretModal
           secretId={viewSecretId}
           onClose={() => setViewSecretId(null)}
+        />
+      )}
+
+      {showRotate && (
+        <RotatePassphraseModal
+          onClose={() => setShowRotate(false)}
+          autoUnsealEnvPresent={autoUnsealEnvPresent}
         />
       )}
     </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -94,6 +94,15 @@ export interface InstallerSource {
 export interface ProbeInstallerResult {
   url: string;
   sha256: string;
+  size_bytes?: number;
+  /** Best-effort hint at what the URL actually returned; useful when the URL
+   *  doesn't point at a built MSI (e.g. a GitHub source-tarball ZIP). */
+  format_hint?: string;
+  /** True when the bytes match the expected file format for the kind (e.g.
+   *  OLE2 magic for orion-msi). When false the registration endpoint will
+   *  refuse to persist the source. */
+  format_ok?: boolean;
+  format_error?: string | null;
 }
 
 export interface CreateInstallerSourceData {
@@ -235,6 +244,29 @@ export interface AdminEntityOverview {
 
 export interface VaultStatus {
   status: 'uninitialized' | 'sealed' | 'unsealed';
+  /** True when SAO_VAULT_PASSPHRASE is set in the runtime env. After a
+   *  rotation the operator must update this secret before the next restart,
+   *  or auto-unseal will fail and the vault will boot sealed. */
+  auto_unseal_env_present?: boolean;
+}
+
+export interface ConfigureVaultData {
+  passphrase: string;
+  passphrase_confirmation: string;
+}
+
+export interface RotateVaultPassphraseData {
+  current_passphrase: string;
+  new_passphrase: string;
+  new_passphrase_confirmation: string;
+}
+
+export interface VaultLifecycleResponse {
+  status: 'unsealed';
+  auto_unseal_env_present?: boolean;
+  /** Set by the rotation endpoint when SAO_VAULT_PASSPHRASE is configured —
+   *  the deployment-side secret is now stale and must be rotated to match. */
+  auto_unseal_env_stale?: boolean;
 }
 
 export interface CreateSecretData {

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,0 +1,46 @@
+# Local Windows dev build helper for SAO.
+#
+# Sets the OpenSSL environment variables required by `webauthn-rs` -> `openssl-sys`
+# on x86_64-pc-windows-msvc with the workspace's `+crt-static` rustflags, then
+# invokes cargo. See `.cargo/config.toml` for the full motivation.
+#
+# Usage examples:
+#   pwsh -File scripts/build-windows.ps1                            # cargo build --workspace --all-targets
+#   pwsh -File scripts/build-windows.ps1 -Cargo 'test --workspace'  # cargo test --workspace
+#   pwsh -File scripts/build-windows.ps1 -Cargo 'clippy --workspace --all-targets -- -D warnings'
+
+[CmdletBinding()]
+param(
+    [string]$Cargo = 'build --workspace --all-targets',
+    [string]$OpenSslRoot = 'C:\Program Files\OpenSSL-Win64'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $OpenSslRoot)) {
+    Write-Error "OpenSSL not found at '$OpenSslRoot'. Install OpenSSL-Win64 (https://slproweb.com/products/Win32OpenSSL.html) or pass -OpenSslRoot."
+    exit 1
+}
+
+$libDir = Join-Path -Path $OpenSslRoot -ChildPath 'lib\VC\x64\MT'
+if (-not (Test-Path -LiteralPath $libDir)) {
+    Write-Error "OpenSSL static-CRT libs not found at '$libDir'. The MSI's MT (static CRT) libs are required because .cargo/config.toml pins +crt-static."
+    exit 1
+}
+
+$includeDir = Join-Path -Path $OpenSslRoot -ChildPath 'include'
+
+$env:OPENSSL_DIR = $OpenSslRoot
+$env:OPENSSL_LIB_DIR = $libDir
+$env:OPENSSL_INCLUDE_DIR = $includeDir
+$env:OPENSSL_STATIC = '1'
+
+Write-Host "OPENSSL_DIR     = $($env:OPENSSL_DIR)"
+Write-Host "OPENSSL_LIB_DIR = $($env:OPENSSL_LIB_DIR)"
+Write-Host "OPENSSL_STATIC  = $($env:OPENSSL_STATIC)"
+Write-Host ''
+Write-Host "cargo $Cargo"
+
+$cargoArgs = $Cargo -split '\s+' | Where-Object { $_ -ne '' }
+& cargo @cargoArgs
+exit $LASTEXITCODE

--- a/scripts/smoke-bundle-serve-validation.ps1
+++ b/scripts/smoke-bundle-serve-validation.ps1
@@ -1,0 +1,114 @@
+# Live test: with an installer_sources row that points at a non-MSI URL, the
+# bundle download endpoint must refuse rather than producing a broken ZIP.
+#
+# Assumes Compose is up with SAO_LOCAL_BOOTSTRAP=true already executed and a
+# bad installer_sources row already registered (the user's original failure
+# state). Creates a fresh smoke agent so we don't depend on prior state.
+
+[CmdletBinding()]
+param(
+    [string]$BaseUrl = 'http://localhost:3100',
+    [string]$AdminUsername = 'local-admin'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-DevToken {
+    docker compose -f docker/docker-compose.yml --env-file .env run --rm `
+        -e SAO_LOCAL_BOOTSTRAP=true `
+        -e SAO_LOCAL_ADMIN_USERNAME="$AdminUsername" `
+        sao sao-server mint-dev-token | Select-Object -Last 1
+}
+
+function New-CsrfSession {
+    $session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+    $null = Invoke-WebRequest -Uri "$BaseUrl/api/health" -WebSession $session -UseBasicParsing
+    $cookies = $session.Cookies.GetCookies($BaseUrl)
+    $csrf = $cookies | Where-Object { $_.Name -eq 'sao_csrf' } | Select-Object -ExpandProperty Value
+    if (-not $csrf) { throw 'Server did not issue an sao_csrf cookie.' }
+    return [pscustomobject]@{ Session = $session; CsrfToken = $csrf }
+}
+
+function Wait-ForHealth {
+    for ($i = 0; $i -lt 60; $i++) {
+        try {
+            Invoke-RestMethod -Uri "$BaseUrl/api/health" -TimeoutSec 3 | Out-Null
+            return
+        }
+        catch { Start-Sleep -Seconds 2 }
+    }
+    throw "SAO did not become healthy at $BaseUrl"
+}
+
+Push-Location (Resolve-Path (Join-Path $PSScriptRoot '..'))
+try {
+    Wait-ForHealth
+    $token = Get-DevToken
+    if (-not $token) { throw 'Failed to mint dev bearer token.' }
+    Write-Host 'Got dev bearer token.'
+
+    $csrf = New-CsrfSession
+
+    # Configure Ollama so we can create an agent (any provider works; bundle path is provider-agnostic).
+    $providerHeaders = @{
+        'Authorization' = "Bearer $token"
+        'X-CSRF-Token'  = $csrf.CsrfToken
+    }
+    $providerBody = @{
+        enabled         = $true
+        base_url        = 'http://host.docker.internal:11434'
+        approved_models = @('llama3.2')
+        default_model   = 'llama3.2'
+    } | ConvertTo-Json
+    Invoke-RestMethod -Uri "$BaseUrl/api/admin/llm-providers/ollama" -Method Put `
+        -Headers $providerHeaders -ContentType 'application/json' -Body $providerBody `
+        -WebSession $csrf.Session | Out-Null
+
+    $agentName = "smoke-bundle-$([guid]::NewGuid().ToString().Substring(0,8))"
+    $agentBody = @{
+        name              = $agentName
+        default_provider  = 'ollama'
+        default_id_model  = 'llama3.2'
+        default_ego_model = 'llama3.2'
+    } | ConvertTo-Json
+    $agent = Invoke-RestMethod -Uri "$BaseUrl/api/agents" -Method Post `
+        -Headers $providerHeaders -ContentType 'application/json' -Body $agentBody `
+        -WebSession $csrf.Session
+    $agentId = $agent.agent_id
+    if (-not $agentId) { throw "Agent create did not return an id: $($agent | ConvertTo-Json -Depth 5)" }
+    Write-Host "Created smoke agent $agentName ($agentId)."
+
+    try {
+        $bundleResp = Invoke-WebRequest -Uri "$BaseUrl/api/agents/$agentId/bundle" `
+            -Headers $providerHeaders -WebSession $csrf.Session -UseBasicParsing
+        # If we reach here, the bundle download succeeded — this is the BUG state, not the fix state.
+        $bytes = $bundleResp.Content
+        $magicHex = ([System.BitConverter]::ToString($bytes[0..3])).Replace('-', '').ToLower()
+        throw "Bundle download succeeded with $($bytes.Length) bytes (magic=$magicHex). Expected 503."
+    }
+    catch {
+        $resp = $_.Exception.Response
+        if (-not $resp) { throw }
+        $status = [int]$resp.StatusCode
+        $rawBody = $null
+        if ($_.ErrorDetails -and $_.ErrorDetails.Message) { $rawBody = $_.ErrorDetails.Message }
+        $parsed = $null
+        if ($rawBody) {
+            try { $parsed = $rawBody | ConvertFrom-Json } catch { $parsed = $rawBody }
+        }
+        if ($status -ne 503) {
+            throw "Expected 503 from bundle endpoint; got $status $($parsed | ConvertTo-Json -Compress -Depth 5)"
+        }
+        if ($parsed.error -notmatch 'installer' -and $parsed.error -notmatch 'msi' -and $parsed.error -notmatch 'Installer') {
+            throw "Expected installer-related error message; got $($parsed | ConvertTo-Json -Compress -Depth 5)"
+        }
+        Write-Host "OK: bundle endpoint returned 503 with a clear installer error:"
+        Write-Host "    $($parsed.error)"
+    }
+
+    Write-Host ''
+    Write-Host 'Bundle-serve format validation smoke test passed.'
+}
+finally {
+    Pop-Location
+}

--- a/scripts/smoke-installer-validation.ps1
+++ b/scripts/smoke-installer-validation.ps1
@@ -1,0 +1,134 @@
+# Live smoke for the installer-source format validator.
+#
+# Verifies that:
+#   1. /api/admin/installer-sources/probe rejects a non-MSI URL with a clear
+#      format_ok=false + format_hint signal.
+#   2. /api/admin/installer-sources refuses to persist a non-MSI URL even when
+#      the caller has a matching sha256 (the original failure mode the user hit).
+#
+# Assumes Compose is up with SAO_LOCAL_BOOTSTRAP=true already executed and an
+# admin user provisioned. Intentionally uses a real public URL that is known
+# to return a non-MSI: GitHub's auto-generated source-tarball alias.
+
+[CmdletBinding()]
+param(
+    [string]$BaseUrl = 'http://localhost:3100',
+    [string]$AdminUsername = 'local-admin',
+    # GitHub auto-generated source archive — NOT an MSI. This is the exact URL
+    # convention that bit the user.
+    [string]$BadUrl =
+      'https://github.com/jbcupps/OrionII/archive/refs/tags/dev0.1.zip'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-DevToken {
+    docker compose -f docker/docker-compose.yml --env-file .env run --rm `
+        -e SAO_LOCAL_BOOTSTRAP=true `
+        -e SAO_LOCAL_ADMIN_USERNAME="$AdminUsername" `
+        sao sao-server mint-dev-token | Select-Object -Last 1
+}
+
+function Wait-ForHealth {
+    for ($i = 0; $i -lt 60; $i++) {
+        try {
+            Invoke-RestMethod -Uri "$BaseUrl/api/health" -TimeoutSec 3 | Out-Null
+            return
+        }
+        catch { Start-Sleep -Seconds 2 }
+    }
+    throw "SAO did not become healthy at $BaseUrl"
+}
+
+function New-CsrfSession {
+    $session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+    $null = Invoke-WebRequest -Uri "$BaseUrl/api/health" -WebSession $session -UseBasicParsing
+    $cookies = $session.Cookies.GetCookies($BaseUrl)
+    $csrf = $cookies | Where-Object { $_.Name -eq 'sao_csrf' } | Select-Object -ExpandProperty Value
+    if (-not $csrf) { throw 'Server did not issue an sao_csrf cookie.' }
+    return [pscustomobject]@{ Session = $session; CsrfToken = $csrf }
+}
+
+function Invoke-AdminApi {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] $Body,
+        [Parameter(Mandatory)] [string]$Token,
+        [Parameter(Mandatory)] $Csrf
+    )
+    $headers = @{
+        'Authorization' = "Bearer $Token"
+        'X-CSRF-Token'  = $Csrf.CsrfToken
+    }
+    $bodyJson = ConvertTo-Json -InputObject $Body -Depth 5
+    try {
+        $response = Invoke-WebRequest -Uri "$BaseUrl$Path" -Method Post -Headers $headers `
+            -ContentType 'application/json' -Body $bodyJson `
+            -WebSession $Csrf.Session -UseBasicParsing
+        $parsed = if ($response.Content) { $response.Content | ConvertFrom-Json } else { $null }
+        return [pscustomobject]@{ Status = [int]$response.StatusCode; Body = $parsed }
+    }
+    catch {
+        $resp = $_.Exception.Response
+        if (-not $resp) { throw }
+        $rawBody = $null
+        if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+            $rawBody = $_.ErrorDetails.Message
+        }
+        $parsed = $null
+        if ($rawBody) {
+            try { $parsed = $rawBody | ConvertFrom-Json } catch { $parsed = $rawBody }
+        }
+        return [pscustomobject]@{ Status = [int]$resp.StatusCode; Body = $parsed }
+    }
+}
+
+Push-Location (Resolve-Path (Join-Path $PSScriptRoot '..'))
+try {
+    Wait-ForHealth
+    $token = Get-DevToken
+    if (-not $token) { throw 'Failed to mint dev bearer token.' }
+    Write-Host 'Got dev bearer token.'
+
+    $csrf = New-CsrfSession
+    Write-Host 'Acquired sao_csrf cookie.'
+
+    # --- 1. Probe rejects a non-MSI URL with format_ok=false ---------------------
+    $probe = Invoke-AdminApi -Path '/api/admin/installer-sources/probe' -Token $token -Csrf $csrf -Body @{
+        url  = $BadUrl
+        kind = 'orion-msi'
+    }
+    if ($probe.Status -ne 200) {
+        throw "Expected 200 from probe; got $($probe.Status) $($probe.Body | ConvertTo-Json -Compress -Depth 5)"
+    }
+    if ($probe.Body.format_ok -ne $false) {
+        throw "Expected probe format_ok=false; got $($probe.Body | ConvertTo-Json -Compress -Depth 5)"
+    }
+    if (-not $probe.Body.format_hint -or $probe.Body.format_hint -notmatch 'ZIP') {
+        throw "Expected ZIP hint; got format_hint=$($probe.Body.format_hint)"
+    }
+    Write-Host "OK: probe of GitHub source-tarball returned format_ok=false (hint: $($probe.Body.format_hint))."
+
+    # --- 2. Create refuses to persist a non-MSI URL even with a matching sha ----
+    $sha = $probe.Body.sha256
+    $create = Invoke-AdminApi -Path '/api/admin/installer-sources' -Token $token -Csrf $csrf -Body @{
+        kind            = 'orion-msi'
+        url             = $BadUrl
+        filename        = 'OrionII_0.1.0_x64_en-US.msi'
+        version         = 'invalid'
+        expected_sha256 = $sha
+        is_default      = $false
+    }
+    if ($create.Status -ne 400 -or $create.Body.code -ne 'invalid_installer_artifact') {
+        throw "Expected 400 invalid_installer_artifact; got $($create.Status) $($create.Body | ConvertTo-Json -Compress -Depth 5)"
+    }
+    Write-Host "OK: registration of non-MSI URL refused with code=invalid_installer_artifact."
+    Write-Host "    looks_like: $($create.Body.looks_like)"
+
+    Write-Host ''
+    Write-Host 'Installer-source format validation smoke test passed.'
+}
+finally {
+    Pop-Location
+}

--- a/scripts/smoke-vault-passphrase.ps1
+++ b/scripts/smoke-vault-passphrase.ps1
@@ -1,0 +1,166 @@
+# Live smoke test for /api/vault/configure + /api/vault/rotate-passphrase.
+# Assumes Compose is up with SAO_LOCAL_BOOTSTRAP=true already executed and
+# the vault initialized with $InitialPassphrase. Idempotent: rotates twice so
+# the runbook's expected passphrase remains in place at the end.
+
+[CmdletBinding()]
+param(
+    [string]$BaseUrl = 'http://localhost:3100',
+    [string]$InitialPassphrase = 'local-dev-only-change-me',
+    [string]$IntermediatePassphrase = 'rotated-dev-passphrase-#1',
+    [string]$AdminUsername = 'local-admin'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-DevToken {
+    $token = docker compose -f docker/docker-compose.yml --env-file .env run --rm `
+        -e SAO_LOCAL_BOOTSTRAP=true `
+        -e SAO_LOCAL_ADMIN_USERNAME="$AdminUsername" `
+        sao sao-server mint-dev-token | Select-Object -Last 1
+    if (-not $token) { throw 'Failed to mint dev token.' }
+    return $token
+}
+
+function Wait-ForHealth {
+    for ($i = 0; $i -lt 60; $i++) {
+        try {
+            Invoke-RestMethod -Uri "$BaseUrl/api/health" -TimeoutSec 3 | Out-Null
+            return
+        }
+        catch { Start-Sleep -Seconds 2 }
+    }
+    throw "SAO did not become healthy at $BaseUrl"
+}
+
+function New-CsrfSession {
+    $session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+    # First request seeds the sao_csrf cookie for subsequent mutating calls.
+    $null = Invoke-WebRequest -Uri "$BaseUrl/api/health" -WebSession $session -UseBasicParsing
+    $cookies = $session.Cookies.GetCookies($BaseUrl)
+    $csrf = $cookies | Where-Object { $_.Name -eq 'sao_csrf' } | Select-Object -ExpandProperty Value
+    if (-not $csrf) { throw 'Server did not issue an sao_csrf cookie.' }
+    return [pscustomobject]@{ Session = $session; CsrfToken = $csrf }
+}
+
+function Invoke-VaultEndpoint {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] $Body,
+        [Parameter(Mandatory)] [string]$Token,
+        [Parameter(Mandatory)] $Csrf
+    )
+    $headers = @{
+        'Authorization' = "Bearer $Token"
+        'X-CSRF-Token'  = $Csrf.CsrfToken
+    }
+    $bodyJson = ConvertTo-Json -InputObject $Body -Depth 5
+    try {
+        $response = Invoke-WebRequest -Uri "$BaseUrl$Path" -Method Post -Headers $headers `
+            -ContentType 'application/json' -Body $bodyJson `
+            -WebSession $Csrf.Session -UseBasicParsing
+        $parsed = if ($response.Content) { $response.Content | ConvertFrom-Json } else { $null }
+        return [pscustomobject]@{ Status = [int]$response.StatusCode; Body = $parsed }
+    }
+    catch {
+        $resp = $_.Exception.Response
+        if (-not $resp) { throw }
+        $rawBody = $null
+        if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+            $rawBody = $_.ErrorDetails.Message
+        }
+        $parsed = $null
+        if ($rawBody) {
+            try { $parsed = $rawBody | ConvertFrom-Json } catch { $parsed = $rawBody }
+        }
+        return [pscustomobject]@{ Status = [int]$resp.StatusCode; Body = $parsed }
+    }
+}
+
+Push-Location (Resolve-Path (Join-Path $PSScriptRoot '..'))
+try {
+    Wait-ForHealth
+
+    $token = Get-DevToken
+    Write-Host "Got dev token; running vault lifecycle smoke checks."
+
+    $csrf = New-CsrfSession
+    Write-Host "Acquired sao_csrf cookie; proceeding with mutating calls."
+
+    # 1. configure must refuse on an already-initialized vault.
+    $r1 = Invoke-VaultEndpoint -Path '/api/vault/configure' -Token $token -Csrf $csrf -Body @{
+        passphrase              = 'should-not-apply-here-1234'
+        passphrase_confirmation = 'should-not-apply-here-1234'
+    }
+    if ($r1.Status -ne 409 -or $r1.Body.code -ne 'vault_already_initialized') {
+        throw "Expected 409 vault_already_initialized; got $($r1.Status) $($r1.Body | ConvertTo-Json -Compress -Depth 5)"
+    }
+    Write-Host "OK: configure on initialized vault returned 409 (vault_already_initialized)."
+
+    # 2. rotate must reject the wrong current passphrase.
+    $r2 = Invoke-VaultEndpoint -Path '/api/vault/rotate-passphrase' -Token $token -Csrf $csrf -Body @{
+        current_passphrase          = 'definitely-wrong-passphrase-1234'
+        new_passphrase              = 'irrelevant-since-401-1234'
+        new_passphrase_confirmation = 'irrelevant-since-401-1234'
+    }
+    if ($r2.Status -ne 401 -or $r2.Body.code -ne 'invalid_credentials') {
+        throw "Expected 401 invalid_credentials; got $($r2.Status) $($r2.Body | ConvertTo-Json -Compress -Depth 5)"
+    }
+    Write-Host "OK: rotate with wrong current returned 401 (invalid_credentials)."
+
+    # 3. rotate must reject same-as-current.
+    $r3 = Invoke-VaultEndpoint -Path '/api/vault/rotate-passphrase' -Token $token -Csrf $csrf -Body @{
+        current_passphrase          = $InitialPassphrase
+        new_passphrase              = $InitialPassphrase
+        new_passphrase_confirmation = $InitialPassphrase
+    }
+    if ($r3.Status -ne 400 -or $r3.Body.code -ne 'same_as_current') {
+        throw "Expected 400 same_as_current; got $($r3.Status) $($r3.Body | ConvertTo-Json -Compress -Depth 5)"
+    }
+    Write-Host "OK: rotate with same-as-current returned 400 (same_as_current)."
+
+    # 4. rotate to intermediate, verify the new passphrase unseals.
+    $r4 = Invoke-VaultEndpoint -Path '/api/vault/rotate-passphrase' -Token $token -Csrf $csrf -Body @{
+        current_passphrase          = $InitialPassphrase
+        new_passphrase              = $IntermediatePassphrase
+        new_passphrase_confirmation = $IntermediatePassphrase
+    }
+    if ($r4.Status -ne 200 -or $r4.Body.status -ne 'unsealed') {
+        throw "Expected 200 unsealed; got $($r4.Status) $($r4.Body | ConvertTo-Json -Compress -Depth 5)"
+    }
+    Write-Host "OK: rotate to intermediate succeeded."
+
+    # 5. seal vault, then unseal with the intermediate passphrase to prove the new envelope works.
+    $sealHeaders = @{
+        'Authorization' = "Bearer $token"
+        'X-CSRF-Token'  = $csrf.CsrfToken
+    }
+    Invoke-RestMethod -Method Post -Uri "$BaseUrl/api/vault/seal" -Headers $sealHeaders `
+        -WebSession $csrf.Session | Out-Null
+    $unsealBody = @{ passphrase = $IntermediatePassphrase } | ConvertTo-Json
+    $unseal = Invoke-RestMethod -Method Post -Uri "$BaseUrl/api/vault/unseal" `
+        -Headers $sealHeaders -ContentType 'application/json' -Body $unsealBody `
+        -WebSession $csrf.Session
+    if ($unseal.status -ne 'unsealed') {
+        throw "Unseal with intermediate passphrase failed: $($unseal | ConvertTo-Json -Compress -Depth 5)"
+    }
+    Write-Host "OK: unseal with intermediate passphrase succeeded."
+
+    # 6. rotate back to the initial passphrase so the runbook's expected state is preserved.
+    $r6 = Invoke-VaultEndpoint -Path '/api/vault/rotate-passphrase' -Token $token -Csrf $csrf -Body @{
+        current_passphrase          = $IntermediatePassphrase
+        new_passphrase              = $InitialPassphrase
+        new_passphrase_confirmation = $InitialPassphrase
+    }
+    if ($r6.Status -ne 200) {
+        throw "Failed to rotate back to initial: $($r6.Status) $($r6.Body | ConvertTo-Json -Compress -Depth 5)"
+    }
+    Write-Host "OK: rotated back to initial passphrase; vault state preserved for follow-up runs."
+
+    Write-Host ''
+    Write-Host 'Vault passphrase lifecycle smoke test passed.'
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

Three operator-facing hardening changes that were validated as a unit during a single working session.

### 1. Vault passphrase lifecycle

| Endpoint | Behavior |
| --- | --- |
| `POST /api/vault/configure` | First-time setup. Generates a fresh VMK + Argon2id-derived envelope. **Refuses `409 vault_already_initialized`** once a VMK exists so it cannot orphan existing encrypted secrets. |
| `POST /api/vault/rotate-passphrase` | Requires current passphrase. **Re-seals the same VMK** with a fresh salt + nonce. Existing ciphertexts stay valid. Returns `auto_unseal_env_stale: true` when `SAO_VAULT_PASSPHRASE` is set so operators update the deployment-side secret. |

Both are admin-only, CSRF-gated, audited (`vault.configure`, `vault.rotate_passphrase`, `vault.rotate_passphrase.failed`), and rate-limited at 5 / 5 minutes / IP. Server-side strength checks: 12-character minimum, 4096-character ceiling, denylist of common values (NIST SP 800-63B alignment).

UI: `/vault` now handles all three vault states cleanly — `ConfigureVaultCard` for uninitialized, existing unseal screen + admin-only **Rotate passphrase** action for sealed, secrets table + admin-only **Rotate passphrase** button for unsealed.

### 2. Installer-source artifact validation

Root cause of the "This installation package could not be opened" report: an operator pasted a GitHub `archive/refs/tags/<tag>.zip` URL (source-code archive, not an MSI) into `/admin/installer-sources`. SAO sha-verified the bytes but never checked they were actually a Windows Installer.

Now blocked at three layers — probe, fetch, and serve. All four paths refuse to ship non-MSI bytes with categorical error codes (`invalid_installer_artifact`, `sha_mismatch`) and a sniffer hint that names what the URL actually returned (`ZIP archive (PK\x03\x04) — likely a GitHub source-code archive, not a built MSI`). The admin form blocks the **Register** button until the format check passes.

### 3. Windows local-dev helper

`scripts/build-windows.ps1` sets `OPENSSL_DIR` / `OPENSSL_LIB_DIR` / `OPENSSL_INCLUDE_DIR` / `OPENSSL_STATIC` for the `+crt-static` MSVC build pinned in `.cargo/config.toml`. Documented in `README.md` "Development & Contributing" with a note that the Linux CI image (which installs `libssl-dev` system-wide) does not need this. `.gitignore` extended with `*.log` and `compose-config.yml` to keep the working tree clean.

## Test plan

Local validation (mirrors `.github/workflows/ci.yml` exactly):

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 71/71 pass (was 58; added 11 unit tests for vault strength + installer validator + sniffer, plus 2 route-contract tests)
- [x] `npm --prefix frontend test` — 17/17 pass (was 15; added 2 contract tests for configure + rotate)
- [x] `npm --prefix frontend run build` — clean (tsc + vite)
- [x] `python -m unittest discover installer/tests` — 49/49 pass

Live smoke tests against a running Compose stack:

- [x] `scripts/smoke-vault-passphrase.ps1` — all 6 contract paths (configure-on-initialized 409, rotate wrong-current 401, rotate same-as-current 400, rotate→seal→unseal succeeds, rotate-back preserves runbook state)
- [x] `scripts/smoke-installer-validation.ps1` — probe rejects ZIP with `format_ok=false`; register refuses 400 `invalid_installer_artifact`
- [x] `scripts/smoke-bundle-serve-validation.ps1` — bundle endpoint returns 503 with clear hint when a stale non-MSI is cached, instead of producing a broken bundle

## Notes for reviewers

- The MSI magic-bytes check has zero impact on Linux builds — only the kind `orion-msi` is enforced today (forward-compatible to other kinds via `validate_artifact_for_kind`).
- Vault rotation **does not** re-encrypt secrets. Only the master-key envelope changes. This is the expected best-practice behavior and avoids partial-failure windows in a multi-secret vault.
- A separate companion PR in `jbcupps/OrionII` adds an `edge` rolling-release channel + nightly rebuild so SAO operators always have a current MSI URL to register.
